### PR TITLE
Initial lower bound exposure

### DIFF
--- a/dwave/preprocessing/cyfix_variables.pyx
+++ b/dwave/preprocessing/cyfix_variables.pyx
@@ -26,7 +26,7 @@ from dimod cimport cyAdjVectorBQM
 from dimod.vartypes import Vartype
 
 cdef extern from "include/dwave-preprocessing/fix_variables.hpp" namespace "fix_variables_":
-    vector[pair[int, int]] fixQuboVariables[V, B](cppAdjVectorBQM[V, B]& refBQM,
+    pair[double, vector[pair[int, int]]] fixQuboVariables[V, B](cppAdjVectorBQM[V, B]& refBQM,
                                                   cppbool strict) except +
 
 def fix_variables_wrapper(bqm, strict):
@@ -49,5 +49,6 @@ def fix_variables_wrapper(bqm, strict):
         raise ValueError("bqm must be linearly indexed")
 
     cdef cyAdjVectorBQM cybqm = dimod.as_bqm(bqm, cls=AdjVectorBQM)
+    # need to recieve the pair and return lower bound and the list.
     fixed = fixQuboVariables(cybqm.bqm_, bool(strict))
     return {int(v): int(val) for v, val in fixed}

--- a/dwave/preprocessing/include/dwave-preprocessing/fix_variables.hpp
+++ b/dwave/preprocessing/include/dwave-preprocessing/fix_variables.hpp
@@ -102,8 +102,10 @@ fixQuboVariables(dimod::AdjVectorBQM<V, B> &bqm, bool strict) {
   // be equal to the lower bound of the bqm. But while creating the implication
   // network and assigning capacities to its edges we did not divide the
   // corresponding coefficients of the posiform by 2 thus when we convert the
-  // max flow to the minimum value of the posiform we need to divide it by 2 and
-  // hence the multiplication by 0.5 here.
+  // max flow to the minimum value of the posiform we need to divide it by 2.
+  // See bottom of page 5 after equation 5 of the following paper.
+  // Boros, Endre & Hammer, Peter & Tavares, Gabriel. (2006). Preprocessing of
+  // unconstrained quadratic binary optimization. RUTCOR Research Report.
   double lower_bound = ((double)max_flow /(posiform_info.getBiasConversionRatio() * 2));
   return {lower_bound, fixed_variables};
 }

--- a/dwave/preprocessing/include/dwave-preprocessing/fix_variables.hpp
+++ b/dwave/preprocessing/include/dwave-preprocessing/fix_variables.hpp
@@ -106,7 +106,8 @@ fixQuboVariables(dimod::AdjVectorBQM<V, B> &bqm, bool strict) {
   // See bottom of page 5 after equation 5 of the following paper.
   // Boros, Endre & Hammer, Peter & Tavares, Gabriel. (2006). Preprocessing of
   // unconstrained quadratic binary optimization. RUTCOR Research Report.
-  double lower_bound = ((double)max_flow /(posiform_info.getBiasConversionRatio() * 2));
+  double lower_bound = (posiform_info.getConstant() / posiform_info.getBiasConversionRatio())
+                       + ((double)max_flow / (posiform_info.getBiasConversionRatio() * 2));
   return {lower_bound, fixed_variables};
 }
 

--- a/dwave/preprocessing/include/dwave-preprocessing/fix_variables.hpp
+++ b/dwave/preprocessing/include/dwave-preprocessing/fix_variables.hpp
@@ -99,7 +99,8 @@ fixQuboVariables(dimod::AdjVectorBQM<V, B> &bqm, bool strict) {
   capacity_type max_flow = fixQuboVariables(posiform_info, num_bqm_variables, strict, fixed_variables);
 
   // The max_flow is supposed to be the lower bound of the posiform which should
-  // be equal to the lower bound of the bqm. But while creating the implication
+  // be equal to the lower bound of the bqm minus the constant term calculated
+  // while creating the posiform. But while creating the implication
   // network and assigning capacities to its edges we did not divide the
   // corresponding coefficients of the posiform by 2 thus when we convert the
   // max flow to the minimum value of the posiform we need to divide it by 2.

--- a/dwave/preprocessing/include/dwave-preprocessing/fix_variables.hpp
+++ b/dwave/preprocessing/include/dwave-preprocessing/fix_variables.hpp
@@ -98,12 +98,12 @@ fixQuboVariables(dimod::AdjVectorBQM<V, B> &bqm, bool strict) {
   std::vector<std::pair<int, int>> fixed_variables;
   capacity_type max_flow = fixQuboVariables(posiform_info, num_bqm_variables, strict, fixed_variables);
 
-  // The max_flow is supposed to be the lower bound of the posiform which should
-  // be equal to the lower bound of the bqm minus the constant term calculated
-  // while creating the posiform. But while creating the implication
-  // network and assigning capacities to its edges we did not divide the
-  // corresponding coefficients of the posiform by 2 thus when we convert the
-  // max flow to the minimum value of the posiform we need to divide it by 2.
+  // The max_flow added with the constant term of the posiform is supposed to
+  // be the lower bound of the posiform which should be equal to the lower
+  // bound of the bqm. But while creating the implication network and assigning
+  // capacities to its edges we did not divide the corresponding coefficients of
+  // the posiform by 2 thus when we convert the max flow to the minimum value of
+  // the posiform we need to divide it by 2.
   // See bottom of page 5 after equation 5 of the following paper.
   // Boros, Endre & Hammer, Peter & Tavares, Gabriel. (2006). Preprocessing of
   // unconstrained quadratic binary optimization. RUTCOR Research Report.

--- a/dwave/preprocessing/include/dwave-preprocessing/helper_graph_algorithms.hpp
+++ b/dwave/preprocessing/include/dwave-preprocessing/helper_graph_algorithms.hpp
@@ -259,7 +259,7 @@ isMaximumFlow(std::vector<std::vector<EdgeType>> &adjacency_list, int source,
   // sink through any augmenting path.
   std::vector<int> depth_values;
   int UNVISITED = breadthFirstSearchResidual(adjacency_list, sink, depth_values,
-                                             true, true);
+                                             true, false);
   return {validity_result.first,
           (validity_result.second && (depth_values[source] == UNVISITED))};
 }

--- a/dwave/preprocessing/include/dwave-preprocessing/helper_graph_algorithms.hpp
+++ b/dwave/preprocessing/include/dwave-preprocessing/helper_graph_algorithms.hpp
@@ -442,7 +442,8 @@ void createGraphOfStronglyConnectedComponents(
 #pragma omp parallel
   {
     std::vector<int> temp_buffer(num_components);
-    std::vector<bool> found_edge_to_component(num_components, false);
+    // Better not use vector of booleans in parallel regions.
+    std::vector<int> found_edge_to_component(num_components, false);
 #pragma omp for
     for (int component = 0; component < num_components; component++) {
       int num_out_edges = 0;

--- a/dwave/preprocessing/include/dwave-preprocessing/implication_network.hpp
+++ b/dwave/preprocessing/include/dwave-preprocessing/implication_network.hpp
@@ -306,7 +306,6 @@ ImplicationNetwork<capacity_t>::ImplicationNetwork(PosiformInfo &posiform) {
       // See bottom of page 5 after equation 5 of the following paper.
       // Boros, Endre & Hammer, Peter & Tavares, Gabriel. (2006). Preprocessing of
       // unconstrained quadratic binary optimization. RUTCOR Research Report.
-
       auto coefficient = posiform.convertToPosiformCoefficient(it->second);
       int variable_2 = posiform.mapVariableQuboToPosiform(it->first);
       int to_vertex = _mapper.variable_to_vertex(variable_2);

--- a/dwave/preprocessing/include/dwave-preprocessing/implication_network.hpp
+++ b/dwave/preprocessing/include/dwave-preprocessing/implication_network.hpp
@@ -299,6 +299,14 @@ ImplicationNetwork<capacity_t>::ImplicationNetwork(PosiformInfo &posiform) {
       // bqm, thus the variables, must be mapped to the posiform variables,
       // and the biases should be ideally converted to the same type the
       // posiform represens them in.
+      // IMPORTANT NOTE : We skip dividing by 2 when calculating the implication
+      // netowrk edge capacities to avoid rounding errors, but when we compute
+      // the max flow and convert it back to a lower bound for the bqm, we must
+      // take this into account and divide the max flow by 2.
+      // See bottom of page 5 after equation 5 of the following paper.
+      // Boros, Endre & Hammer, Peter & Tavares, Gabriel. (2006). Preprocessing of
+      // unconstrained quadratic binary optimization. RUTCOR Research Report.
+
       auto coefficient = posiform.convertToPosiformCoefficient(it->second);
       int variable_2 = posiform.mapVariableQuboToPosiform(it->first);
       int to_vertex = _mapper.variable_to_vertex(variable_2);

--- a/dwave/preprocessing/include/dwave-preprocessing/implication_network.hpp
+++ b/dwave/preprocessing/include/dwave-preprocessing/implication_network.hpp
@@ -384,7 +384,7 @@ void ImplicationNetwork<capacity_t>::makeResidualSymmetric() {
   // If the edges are sorted even if we create edges to/from vertices
   // corresponding to variables and their complements.
   bool edges_sorted = _mapper.complement_maintains_order();
-#pragma omp parallel for
+#pragma omp parallel for schedule(dynamic)
   for (int vertex = 0; vertex < _num_vertices; vertex++) {
     int from_vertex_base = _mapper.non_complemented_vertex(vertex);
     auto eit = edges_sorted ? std::lower_bound(_adjacency_list[vertex].begin(),

--- a/dwave/preprocessing/include/dwave-preprocessing/posiform_info.hpp
+++ b/dwave/preprocessing/include/dwave-preprocessing/posiform_info.hpp
@@ -143,6 +143,13 @@ public:
   }
 
   /**
+   * Return the value by which bqm biases are multiplied to get posiform coefficients.
+   */
+  inline double getBiasConversionRatio() {
+	return _bias_conversion_ratio;
+  }
+
+  /**
    * Print out posiform details.
    */
   void print();

--- a/dwave/preprocessing/include/dwave-preprocessing/posiform_info.hpp
+++ b/dwave/preprocessing/include/dwave-preprocessing/posiform_info.hpp
@@ -150,6 +150,13 @@ public:
   }
 
   /**
+   * Return the value of the constant term of the posiform.
+   */
+  inline double getConstant() {
+	return _constant_posiform;
+  }
+
+  /**
    * Print out posiform details.
    */
   void print();
@@ -309,6 +316,10 @@ PosiformInfo<BQM, coefficient_t>::PosiformInfo(const BQM &bqm) {
   else {
     // All biases in bqm are 0, so the resulting posiform won't have any term in it.
     _num_posiform_variables = 0;
+    _constant_posiform = 0;
+    _bias_conversion_ratio = 1;
+    _posiform_linear_sum_integral = 0;
+    _num_linear_integral_biases = 0;
   }
 }
 

--- a/testscpp/tests/test_roof_duality.cpp
+++ b/testscpp/tests/test_roof_duality.cpp
@@ -121,7 +121,7 @@ TEST_CASE("Tests for fixQuboVariables", "[roofduality]") {
 
         for (auto mode : {true, false}) {
             auto result = fixQuboVariables(bqm, mode);
-            fixed_vars = result.second;
+            auto fixed_vars = result.second;
             REQUIRE(fixed_vars.size() == 2);
 
             // checking order of variables

--- a/testscpp/tests/test_roof_duality.cpp
+++ b/testscpp/tests/test_roof_duality.cpp
@@ -35,8 +35,10 @@ TEST_CASE("Tests for fixQuboVariables", "[roofduality]") {
 
         // Checking fixQuboVariables(AdjVectorBQM, ..)
         auto result = fixQuboVariables(bqm, true);
+        auto lower_bound = result.first;
         auto fixed_vars2 = result.second;
 
+        REQUIRE(lower_bound == -2);
         REQUIRE(fixed_vars == fixed_vars2);
         REQUIRE(fixed_vars.size() == num_vars);
 
@@ -55,11 +57,17 @@ TEST_CASE("Tests for fixQuboVariables", "[roofduality]") {
         auto bqm = dimod::AdjVectorBQM<int, float>(Q, 0);
 
         auto result = fixQuboVariables(bqm, true);
+        auto lower_bound = result.first;
         auto fixed_vars = result.second;
+
+        REQUIRE(lower_bound == 0);
         REQUIRE(fixed_vars.size() == 0);
 
         result = fixQuboVariables(bqm, false);
+        lower_bound = result.first;
         fixed_vars = result.second;
+
+        REQUIRE(lower_bound == 0);
         REQUIRE(fixed_vars.size() == 0);
     }
 
@@ -72,14 +80,19 @@ TEST_CASE("Tests for fixQuboVariables", "[roofduality]") {
         auto bqm = dimod::AdjVectorBQM<int, float>(Q, num_vars);
 
         auto result = fixQuboVariables(bqm, true);
+        auto lower_bound = result.first;
         auto fixed_vars = result.second;
 
+        REQUIRE(lower_bound == 0);
         REQUIRE(fixed_vars.size() == 1);
         REQUIRE(fixed_vars[0].first == 0);
         REQUIRE(fixed_vars[0].second == 0);
 
         result = fixQuboVariables(bqm, false);
+        lower_bound = result.first;
         fixed_vars = result.second;
+
+        REQUIRE(lower_bound == 0);
         REQUIRE(fixed_vars.size() == 3);
         for (auto var : fixed_vars) {
             if (var.first == 0) {
@@ -100,11 +113,17 @@ TEST_CASE("Tests for fixQuboVariables", "[roofduality]") {
         auto bqm = dimod::AdjVectorBQM<int, float>(Q, num_vars);
 
         auto result = fixQuboVariables(bqm, true);
+        auto lower_bound = result.first;
         auto fixed_vars = result.second;
+
+        REQUIRE(lower_bound == 0);
         REQUIRE(fixed_vars.size() == 0);
 
         result = fixQuboVariables(bqm, false);
+        lower_bound = result.first;
         fixed_vars = result.second;
+
+        REQUIRE(lower_bound == 0);
         REQUIRE(fixed_vars.size() == num_vars);
 
         for (auto var : fixed_vars) {
@@ -121,7 +140,10 @@ TEST_CASE("Tests for fixQuboVariables", "[roofduality]") {
 
         for (auto mode : {true, false}) {
             auto result = fixQuboVariables(bqm, mode);
+            auto lower_bound = result.first;
             auto fixed_vars = result.second;
+
+            REQUIRE(lower_bound == 0);
             REQUIRE(fixed_vars.size() == 2);
 
             // checking order of variables

--- a/testscpp/tests/test_roof_duality.cpp
+++ b/testscpp/tests/test_roof_duality.cpp
@@ -34,7 +34,8 @@ TEST_CASE("Tests for fixQuboVariables", "[roofduality]") {
         fixQuboVariables(posiform, num_vars, true, fixed_vars);
 
         // Checking fixQuboVariables(AdjVectorBQM, ..)
-        auto fixed_vars2 = fixQuboVariables(bqm, true);
+        auto result = fixQuboVariables(bqm, true);
+        auto fixed_vars2 = result.second;
 
         REQUIRE(fixed_vars == fixed_vars2);
         REQUIRE(fixed_vars.size() == num_vars);
@@ -53,10 +54,12 @@ TEST_CASE("Tests for fixQuboVariables", "[roofduality]") {
         float Q [] = {};
         auto bqm = dimod::AdjVectorBQM<int, float>(Q, 0);
 
-        auto fixed_vars = fixQuboVariables(bqm, true);
+        auto result = fixQuboVariables(bqm, true);
+        auto fixed_vars = result.second;
         REQUIRE(fixed_vars.size() == 0);
 
-        fixed_vars = fixQuboVariables(bqm, false);
+        result = fixQuboVariables(bqm, false);
+        fixed_vars = result.second;
         REQUIRE(fixed_vars.size() == 0);
     }
 
@@ -68,12 +71,15 @@ TEST_CASE("Tests for fixQuboVariables", "[roofduality]") {
         int num_vars = 3;
         auto bqm = dimod::AdjVectorBQM<int, float>(Q, num_vars);
 
-        auto fixed_vars = fixQuboVariables(bqm, true);
+        auto result = fixQuboVariables(bqm, true);
+        auto fixed_vars = result.second;
+
         REQUIRE(fixed_vars.size() == 1);
         REQUIRE(fixed_vars[0].first == 0);
         REQUIRE(fixed_vars[0].second == 0);
 
-        fixed_vars = fixQuboVariables(bqm, false);
+        result = fixQuboVariables(bqm, false);
+        fixed_vars = result.second;
         REQUIRE(fixed_vars.size() == 3);
         for (auto var : fixed_vars) {
             if (var.first == 0) {
@@ -93,10 +99,12 @@ TEST_CASE("Tests for fixQuboVariables", "[roofduality]") {
         int num_vars = 2;
         auto bqm = dimod::AdjVectorBQM<int, float>(Q, num_vars);
 
-        auto fixed_vars = fixQuboVariables(bqm, true);
+        auto result = fixQuboVariables(bqm, true);
+        auto fixed_vars = result.second;
         REQUIRE(fixed_vars.size() == 0);
 
-        fixed_vars = fixQuboVariables(bqm, false);
+        result = fixQuboVariables(bqm, false);
+        fixed_vars = result.second;
         REQUIRE(fixed_vars.size() == num_vars);
 
         for (auto var : fixed_vars) {
@@ -112,7 +120,8 @@ TEST_CASE("Tests for fixQuboVariables", "[roofduality]") {
         auto bqm = dimod::AdjVectorBQM<int, float>(Q, num_vars);
 
         for (auto mode : {true, false}) {
-            auto fixed_vars = fixQuboVariables(bqm, mode);
+            auto result = fixQuboVariables(bqm, mode);
+            fixed_vars = result.second;
             REQUIRE(fixed_vars.size() == 2);
 
             // checking order of variables


### PR DESCRIPTION
Wrote the c++ side of exposing the lower bound. The max flow needs to be multiplied by 0.5 and divided by the bias conversion ratio since when we convert the posiform coefficients to implication graph edges we do not divide by 2 when needed for conversion of posiform coefficient to implication network edge capacity as can be seen after equation 5 in page 5 of this paper. https://www.researchgate.net/publication/238379061_Preprocessing_of_unconstrained_quadratic_binary_optimization

