### PR TITLE
Pin dimod for reliable build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,6 @@ requires = [
     "wheel>=0.30.0",
     "Cython>=0.29.21,<3.0",
     "numpy==1.19.4",
-    "dimod>=0.10.0.dev9,<0.11.0",
+    "dimod==0.10.4",
 ]
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-dimod==0.10.0.dev9
+dimod==0.10.4
 Cython==0.29.21
 numpy==1.19.4
 
 # build
 wheel>=0.30.0
 setuptools>=56.2.0
+

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,6 @@ setup(
         ],
     install_requires=[
         'numpy>=1.17.3,<2.0.0',  # keep synced with circle-ci, pyproject.toml
-        'dimod>=0.10.0.dev9,<0.11.0'
+        'dimod>=0.10.0,<0.11.0'
         ],
 )


### PR DESCRIPTION
Also, and more importantly, pin it to a version which does not require
a dwave-preprocessing install.

This is a short-term fix for #28.