### PR TITLE
Changed default num_spin_reversal_transforms to 1. Added special case…

### DIFF
--- a/dwave/preprocessing/composites/spin_reversal_transform.py
+++ b/dwave/preprocessing/composites/spin_reversal_transform.py
@@ -64,19 +64,19 @@ class SpinReversalTransformComposite(Sampler, Composite):
 
         self.properties = {'child_properties': child.properties}
 
-    def sample(self, bqm, *, num_spin_reversal_transforms=2, **kwargs):
+    def sample(self, bqm, *, num_spin_reversal_transforms=1, **kwargs):
         """Sample from the binary quadratic model.
 
         Args:
             bqm (:class:`~dimod.BinaryQuadraticModel`):
                 Binary quadratic model to be sampled from.
 
-            num_spin_reversal_transforms (integer, optional, default=2):
+            num_spin_reversal_transforms (integer, optional, default=1):
                 Number of spin reversal transform runs.
 
         Returns:
             :class:`.SampleSet`
-
+        
         Examples:
             This example runs 100 spin reversals applied to one variable of a QUBO problem.
 
@@ -97,7 +97,7 @@ class SpinReversalTransformComposite(Sampler, Composite):
 
         flipped_bqm = bqm.copy()
         transform = {v: False for v in bqm.variables}
-
+        
         for ii in range(num_spin_reversal_transforms):
             # flip each variable with a 50% chance
             for v in bqm.variables:
@@ -115,6 +115,12 @@ class SpinReversalTransformComposite(Sampler, Composite):
             else:
                 flipped_response.record.sample[:, tf_idxs] = 1 - flipped_response.record.sample[:, tf_idxs]
 
-            responses.append(flipped_response)
+            if num_spin_reversal_transforms == 1:
+                #Case of a single sampleset call, avoid
+                #stripping of info field and other
+                #information. 
+                return(flipped_response)
+            else:
+                responses.append(flipped_response)
 
         return concatenate(responses)

--- a/tests/test_spin_reversal_transform.py
+++ b/tests/test_spin_reversal_transform.py
@@ -14,19 +14,22 @@
 
 import unittest
 
-from dwave.system.testing import MockDWaveSampler
 from dimod import NullSampler, ExactSolver, RandomSampler, SimulatedAnnealingSampler
-from greedy import SteepestDescentSolver
+
 import dimod.testing as dtest
 
 from dwave.preprocessing.composites import SpinReversalTransformComposite
 
-import numpy as np
+
+
+# Running a set of tests similar to the Greedy tests would make sense:
+# import dimod
+# @dimod.testing.load_sampler_bqm_tests(dimod.SpinReversalTransformComposite(dimod.ExactSolver()))
 
 class TestSpinTransformComposite(unittest.TestCase):
     def test_instantiation(self):
         for factory in [ExactSolver, RandomSampler, SimulatedAnnealingSampler,
-                        MockDWaveSampler, NullSampler, SteepestDescentSolver]:
+                        NullSampler]:
             sampler = SpinReversalTransformComposite(factory())
 
             dtest.assert_sampler_api(sampler)
@@ -37,32 +40,37 @@ class TestSpinTransformComposite(unittest.TestCase):
         
         sampler = SpinReversalTransformComposite(NullSampler())
         sampleset = sampler.sample_ising({'a': 1},{},num_spin_reversals=1)
+        
         self.assertTrue(len(sampleset)==0)
         sampleset = sampler.sample_ising({'a': 1},{},num_spin_reversals=2)
+        
         self.assertTrue(len(sampleset)==0)
         
-    def test_concatenation_size(self):
-        # Check that concatenation works, and that when concatenation
-        # is not applied (num_spin_reversal_transforms=1, Default)
-        # information is not stripped from the sampleset.
+    def test_concatenation_stripping(self):
+        # Check samplesets are not stripped of information
+        # under default operation
+
+
+        # Simple sampler with an info field.
+        # When multiple samplesets needn't be recombined, this should
+        # be maintained
+        class RichSampler(NullSampler):
+            def sample_ising(self, *args, **kwargs):
+                ss = super().sample_ising(*args, **kwargs)
+                ss.info['hello'] = 'world'
+                return ss
         
-        sampler = SpinReversalTransformComposite(MockDWaveSampler())
-        num_reads = 1
-        for num_spin_reversal_transforms in [1,2]:
-            sampleset = sampler.sample_ising(
-                {0: 1},{},
-                num_spin_reversal_transforms=num_spin_reversal_transforms,
-                num_reads=num_reads)
-            self.assertTrue(sum(sampleset.record.num_occurrences)==
-                            num_reads*num_spin_reversal_transforms)
-            if num_spin_reversal_transforms == 1:
-                self.assertTrue(hasattr(sampleset,'info'))
-            
+        sampler = SpinReversalTransformComposite(RichSampler())
+        
+        sampleset = sampler.sample_ising(
+            {0: 1},{})
+        self.assertTrue(hasattr(sampleset,'info'))
+        
     def test_sampleset_size(self):
         # Check num_reads and num_spin_reversal_transforms combine
         # for anticipated number of samples.
         
-        sampler = SpinReversalTransformComposite(MockDWaveSampler())
+        sampler = SpinReversalTransformComposite(RandomSampler())
         for num_spin_reversal_transforms in [1,2]:
             for num_reads in [1,3]:
                 sampleset = sampler.sample_ising(
@@ -72,38 +80,41 @@ class TestSpinTransformComposite(unittest.TestCase):
                 self.assertTrue(sum(sampleset.record.num_occurrences)==
                                 num_reads*num_spin_reversal_transforms)
                 
-            
-    def test_sign_errors_vars(self):
-        # Check that when an SRT is applied, sample sign is properly reversed.
-        # Unique ground state of independent h=-1 biased variables is all +1. 
-        
-        sampler = SpinReversalTransformComposite(SteepestDescentSolver())
-        
-        sampleset = sampler.sample_ising({i: -1 for i in range(10)},{},
-                                         num_spin_reversal_transforms=1,
-                                         num_reads=1)
-        self.assertTrue((sampleset.record.sample==1).all())
-        
-        sampleset = sampler.sample_ising({i: -1 for i in range(10)},{},
-                                         num_spin_reversal_transforms=10,
-                                         num_reads=1)
-        
-        self.assertTrue((sampleset.record.sample==1).all())
-        
-    def test_sign_errors_couplers(self):
-        # Check that when an SRT is applied, sample sign is properly reversed.
-        # Unique ground state of a ferromagnetically coupled pair has two
-        # values equal, ground state can be found by steepest descent.
-        
-        sampler = SpinReversalTransformComposite(SteepestDescentSolver())
-        
-        sampleset = sampler.sample_ising({},{(0,1) : -1},
-                                         num_spin_reversal_transforms=1,
-                                         num_reads=1)
-        self.assertTrue((np.prod(sampleset.record.sample,axis=1)==1).all())
-        
-        sampleset = sampler.sample_ising({i: -1 for i in range(10)},{},
-                                         num_spin_reversal_transforms=10,
-                                         num_reads=1)
-        
-        self.assertTrue((sampleset.record.sample==1).all())
+
+# Tests are removed to limit external dependencies
+# from greedy import SteepestDescentSolver
+# import numpy as np
+#    def test_sign_errors_vars(self):
+#        # Check that when an SRT is applied, sample sign is properly reversed.
+#        # Unique ground state of independent h=-1 biased variables is all +1. 
+#        
+#        sampler = SpinReversalTransformComposite(SteepestDescentSolver())
+#        
+#        sampleset = sampler.sample_ising({i: -1 for i in range(10)},{},
+#                                         num_spin_reversal_transforms=1,
+#                                         num_reads=1)
+#        self.assertTrue((sampleset.record.sample==1).all())
+#        
+#        sampleset = sampler.sample_ising({i: -1 for i in range(10)},{},
+#                                         num_spin_reversal_transforms=10,
+#                                         num_reads=1)
+#        
+#        self.assertTrue((sampleset.record.sample==1).all())
+#        
+#    def test_sign_errors_couplers(self):
+#        # Check that when an SRT is applied, sample sign is properly reversed.
+#        # Unique ground state of a ferromagnetically coupled pair has two
+#        # values equal, ground state can be found by steepest descent.
+#        
+#        sampler = SpinReversalTransformComposite(SteepestDescentSolver())
+#        
+#        sampleset = sampler.sample_ising({},{(0,1) : -1},
+#                                         num_spin_reversal_transforms=1,
+#                                         num_reads=1)
+#        self.assertTrue((np.prod(sampleset.record.sample,axis=1)==1).all())
+#        
+#        sampleset = sampler.sample_ising({i: -1 for i in range(10)},{},
+#                                         num_spin_reversal_transforms=10,
+#                                         num_reads=1)
+#        
+#        self.assertTrue((sampleset.record.sample==1).all())

--- a/tests/test_spin_reversal_transform.py
+++ b/tests/test_spin_reversal_transform.py
@@ -14,15 +14,96 @@
 
 import unittest
 
-from dimod import ExactSolver, RandomSampler, SimulatedAnnealingSampler
+from dwave.system.testing import MockDWaveSampler
+from dimod import NullSampler, ExactSolver, RandomSampler, SimulatedAnnealingSampler
+from greedy import SteepestDescentSolver
 import dimod.testing as dtest
 
 from dwave.preprocessing.composites import SpinReversalTransformComposite
 
+import numpy as np
+
 class TestSpinTransformComposite(unittest.TestCase):
     def test_instantiation(self):
-        for factory in [ExactSolver, RandomSampler, SimulatedAnnealingSampler]:
+        for factory in [ExactSolver, RandomSampler, SimulatedAnnealingSampler,
+                        MockDWaveSampler, NullSampler, SteepestDescentSolver]:
             sampler = SpinReversalTransformComposite(factory())
 
             dtest.assert_sampler_api(sampler)
             dtest.assert_composite_api(sampler)
+            
+    def test_NullSampler_composition(self):
+        # Check NullSampler() works, this was a reported bug.
+        
+        sampler = SpinReversalTransformComposite(NullSampler())
+        sampleset = sampler.sample_ising({'a': 1},{},num_spin_reversals=1)
+        self.assertTrue(len(sampleset)==0)
+        sampleset = sampler.sample_ising({'a': 1},{},num_spin_reversals=2)
+        self.assertTrue(len(sampleset)==0)
+        
+    def test_concatenation_size(self):
+        # Check that concatenation works, and that when concatenation
+        # is not applied (num_spin_reversal_transforms=1, Default)
+        # information is not stripped from the sampleset.
+        
+        sampler = SpinReversalTransformComposite(MockDWaveSampler())
+        num_reads = 1
+        for num_spin_reversal_transforms in [1,2]:
+            sampleset = sampler.sample_ising(
+                {0: 1},{},
+                num_spin_reversal_transforms=num_spin_reversal_transforms,
+                num_reads=num_reads)
+            self.assertTrue(sum(sampleset.record.num_occurrences)==
+                            num_reads*num_spin_reversal_transforms)
+            if num_spin_reversal_transforms == 1:
+                self.assertTrue(hasattr(sampleset,'info'))
+            
+    def test_sampleset_size(self):
+        # Check num_reads and num_spin_reversal_transforms combine
+        # for anticipated number of samples.
+        
+        sampler = SpinReversalTransformComposite(MockDWaveSampler())
+        for num_spin_reversal_transforms in [1,2]:
+            for num_reads in [1,3]:
+                sampleset = sampler.sample_ising(
+                    {0: 1},{},
+                    num_spin_reversal_transforms=num_spin_reversal_transforms,
+                    num_reads=num_reads)
+                self.assertTrue(sum(sampleset.record.num_occurrences)==
+                                num_reads*num_spin_reversal_transforms)
+                
+            
+    def test_sign_errors_vars(self):
+        # Check that when an SRT is applied, sample sign is properly reversed.
+        # Unique ground state of independent h=-1 biased variables is all +1. 
+        
+        sampler = SpinReversalTransformComposite(SteepestDescentSolver())
+        
+        sampleset = sampler.sample_ising({i: -1 for i in range(10)},{},
+                                         num_spin_reversal_transforms=1,
+                                         num_reads=1)
+        self.assertTrue((sampleset.record.sample==1).all())
+        
+        sampleset = sampler.sample_ising({i: -1 for i in range(10)},{},
+                                         num_spin_reversal_transforms=10,
+                                         num_reads=1)
+        
+        self.assertTrue((sampleset.record.sample==1).all())
+        
+    def test_sign_errors_couplers(self):
+        # Check that when an SRT is applied, sample sign is properly reversed.
+        # Unique ground state of a ferromagnetically coupled pair has two
+        # values equal, ground state can be found by steepest descent.
+        
+        sampler = SpinReversalTransformComposite(SteepestDescentSolver())
+        
+        sampleset = sampler.sample_ising({},{(0,1) : -1},
+                                         num_spin_reversal_transforms=1,
+                                         num_reads=1)
+        self.assertTrue((np.prod(sampleset.record.sample,axis=1)==1).all())
+        
+        sampleset = sampler.sample_ising({i: -1 for i in range(10)},{},
+                                         num_spin_reversal_transforms=10,
+                                         num_reads=1)
+        
+        self.assertTrue((sampleset.record.sample==1).all())

--- a/tests/test_spin_reversal_transform.py
+++ b/tests/test_spin_reversal_transform.py
@@ -14,9 +14,9 @@
 
 import unittest
 
-from dimod import NullSampler, ExactSolver, RandomSampler, SimulatedAnnealingSampler
-
 import dimod.testing as dtest
+
+from dimod import NullSampler, ExactSolver, RandomSampler, SimulatedAnnealingSampler
 
 from dwave.preprocessing.composites import SpinReversalTransformComposite
 


### PR DESCRIPTION
This issue 
https://github.com/dwavesystems/dwave-preprocessing/issues/33
appears to be closed (without modifications, could not reproduce error, but added test).

Re:  https://github.com/dwavesystems/dimod/issues/813
The default num_spin_reversal_transforms should be 1. A user of a sampler should have a reasonable expectation that setting only num_reads, they receive a sampleset of num_reads samples. Amongst other advantages of this default.

Added a variety of tests.
