### PR TITLE
Update dependency versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,11 +28,6 @@ jobs:
       - restore_cache: &build-linux-restore-cache
           keys:
             - pip-{{ .Environment.CIRCLE_JOB }}-{{ checksum "pyproject.toml" }}
-      - when:
-          condition:
-            equal: [3.6.8, << parameters.python-version>>]
-          steps:
-            - run: echo 'export CIBW_MANYLINUX_X86_64_IMAGE=manylinux1' >> $BASH_ENV
       - run: &build-linux-wheels
           name: build wheels
           command: |
@@ -388,7 +383,7 @@ workflows:
       - build-linux: &build
           matrix:
             parameters:
-              python-version: &python-versions [3.6.8, 3.7.9, 3.8.9, 3.9.4, 3.10.0]
+              python-version: &python-versions [3.7.9, 3.8.9, 3.9.4, 3.10.0]
       - build-linux-aarch64: *build
       - build-sdist
       - build-osx: &build-osx
@@ -397,87 +392,34 @@ workflows:
               python-version: *python-versions
               cibw-arch: [x86_64, universal2]
             exclude:
-              - python-version: 3.6.8
-                cibw-arch: universal2
               - python-version: 3.7.9
                 cibw-arch: universal2
       - build-windows: *build
       - test-codecov
       - test-doctest
       - test-linux:
-          name: test-linux-numpy<< matrix.numpy-version >>-py<< matrix.python-version >>
+          name: test-linux-numpy<< matrix.numpy-version >>-dimod<< matrix.dimod-version >>-py<< matrix.python-version >>
           requires:
             - build-linux
           matrix:
             parameters:
               # test the lowest and highest of each minor for the dependencies
-              dimod-version: [==0.10.0, ~=0.10.0]
-              numpy-version: [==1.17.3, ~=1.18.0, ~=1.19.0, ~=1.20.0, ~=1.21.0]
+              dimod-version: [==0.11.0rc0]  # todo: add ~=0.11.0
+              numpy-version: [==1.19.1, ~=1.20.0, ~=1.21.0, ~=1.22.0]
               python-version: *python-versions
             exclude:
-              - numpy-version: ==1.17.3
-                dimod-version: ==0.10.0
+              - numpy-version: ==1.19.1  # NumPy 1.19.1 does not support 3.9
+                dimod-version: ==0.11.0rc0
                 python-version: 3.9.4
-              - numpy-version: ==1.17.3
-                dimod-version: ==0.10.0
+              - numpy-version: ==1.19.1  # NumPy 1.19.1 does not support 3.10
+                dimod-version: ==0.11.0rc0
                 python-version: 3.10.0
-              - numpy-version: ~=1.18.0
-                dimod-version: ==0.10.0
-                python-version: 3.9.4
-              - numpy-version: ~=1.18.0
-                dimod-version: ==0.10.0
+              - numpy-version: ~=1.20.0  # NumPy 1.20 does not support 3.10
+                dimod-version: ==0.11.0rc0
                 python-version: 3.10.0
-              - numpy-version: ~=1.19.0
-                dimod-version: ==0.10.0
-                python-version: 3.10.0
-              - numpy-version: ~=1.20.0
-                dimod-version: ==0.10.0
-                python-version: 3.6.8
-              - numpy-version: ~=1.20.0
-                dimod-version: ==0.10.0
-                python-version: 3.10.0
-              - numpy-version: ~=1.21.0
-                dimod-version: ==0.10.0
-                python-version: 3.6.8
-              - numpy-version: ==1.17.3
-                dimod-version: ~=0.10.0
-                python-version: 3.9.4
-              - numpy-version: ==1.17.3
-                dimod-version: ~=0.10.0
-                python-version: 3.10.0
-              - numpy-version: ~=1.18.0
-                dimod-version: ~=0.10.0
-                python-version: 3.9.4
-              - numpy-version: ~=1.18.0
-                dimod-version: ~=0.10.0
-                python-version: 3.10.0
-              - numpy-version: ~=1.19.0
-                dimod-version: ~=0.10.0
-                python-version: 3.10.0
-              - numpy-version: ~=1.20.0
-                dimod-version: ~=0.10.0
-                python-version: 3.6.8
-              - numpy-version: ~=1.20.0
-                dimod-version: ~=0.10.0
-                python-version: 3.10.0
-              - numpy-version: ~=1.21.0
-                dimod-version: ~=0.10.0
-                python-version: 3.6.8
-              - numpy-version: ==1.17.3
-                dimod-version: ==0.10.0
-                python-version: 3.10.0
-              - numpy-version: ~=1.18.0
-                dimod-version: ==0.10.0
-                python-version: 3.10.0
-              - numpy-version: ~=1.19.0
-                dimod-version: ==0.10.0
-                python-version: 3.10.0
-              - numpy-version: ~=1.20.0
-                dimod-version: ==0.10.0
-                python-version: 3.10.0
-              - numpy-version: ~=1.21.0
-                dimod-version: ==0.10.0
-                python-version: 3.10.0
+              - numpy-version: ~=1.22.0  # NumPy 1.22 does not support 3.7
+                dimod-version: ==0.11.0rc0
+                python-version: 3.7.9
       - test-linux-cpp11
       - test-osx:
           name: test-osx-py<< matrix.python-version >>
@@ -485,12 +427,7 @@ workflows:
             - build-osx
           matrix:
             parameters:
-              python-version: *python-versions
-            exclude:
-              # this doesn't play nicely with the xcode version we're using.
-              # rather than mess around with https://github.com/pyenv/pyenv/issues/1740
-              # etc let's just skip until december
-              - python-version: 3.6.8            
+              python-version: *python-versions       
       - test-sdist:
           requires:
             - build-sdist

--- a/dwave/preprocessing/include/dwave-preprocessing/posiform_info.hpp
+++ b/dwave/preprocessing/include/dwave-preprocessing/posiform_info.hpp
@@ -210,13 +210,11 @@ PosiformInfo<BQM, coefficient_t>::PosiformInfo(const BQM &bqm) {
     if (_max_absolute_value < bqm_linear_abs) {
       _max_absolute_value = bqm_linear_abs;
     }
-    auto span = bqm.neighborhood(bqm_variable);
-    auto it = std::lower_bound(span.first, span.second, bqm_variable + 1,
-                               dimod::utils::comp_v<variable_type, bias_type>);
-    _quadratic_iterators[bqm_variable] = {it, span.second};
-    if (it != span.second) {
-      for (auto it_end = span.second; it != it_end; it++) {
-        auto bqm_quadratic = it->second;
+    auto span = bqm.neighborhood(bqm_variable, bqm_variable + 1);
+    _quadratic_iterators[bqm_variable] = span;
+    if (span.first != span.second) {
+      for (auto it_end = span.second; span.first != it_end; span.first++) {
+        auto bqm_quadratic = span.first->second;
         auto bqm_quadratic_abs = std::fabs(bqm_quadratic);
         if (bqm_quadratic < 0) {
           _linear_double_biases[bqm_variable] += bqm_quadratic;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,6 @@ requires = [
     "Cython>=0.29.21,<3.0",
     'numpy==1.19.5;python_version<"3.10"',
     'numpy==1.21.4;python_version>="3.10"',
-    "dimod==0.10.9",
+    "dimod==0.11.0rc0",
 ]
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dimod==0.10.9
+dimod==0.11.0rc0
 Cython==0.29.21
 numpy==1.19.5;python_version<"3.10"
 numpy==1.21.4;python_version>="3.10"

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,6 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -25,5 +24,5 @@ packages =
     dwave
     dwave.preprocessing
     dwave.preprocessing.composites
-python_requires = >=3.6
+python_requires = >=3.7
 zip_safe = False

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
         dimod.get_include(),
         ],
     install_requires=[
-        'numpy>=1.17.3,<2.0.0',  # keep synced with circle-ci, pyproject.toml
-        'dimod>=0.10.0,<0.11.0'
+        'numpy>=1.19.1,<2.0.0',  # keep synced with circle-ci, pyproject.toml
+        'dimod>=0.11.0rc0,<0.12.0'
         ],
 )


### PR DESCRIPTION
Build and support dimod~=0.11.0
Increase NumPy lower bound to 1.19.1
Drop support for Python 3.6