### PR TITLE
Update doxygen defintion of fixQuboVariables

### DIFF
--- a/docs/reference/cpp.rst
+++ b/docs/reference/cpp.rst
@@ -6,7 +6,7 @@ C++ API
 
 Functions
 ---------
-.. doxygenfunction:: fixQuboVariables(dimod::AdjVectorBQM<V, B> &bqm, bool sample, double offset)
+.. doxygenfunction:: fixQuboVariables(dimod::BinaryQuadraticModel<B, V> &bqm, bool sample, double offset)
     :project: dwave-preprocessing
 .. doxygenfunction:: fixQuboVariables(PosiformInfo &posiform_info, int num_bqm_variables, bool sample, std::vector<std::pair<int, int>> &fixed_variables)
     :project: dwave-preprocessing


### PR DESCRIPTION
To enable C++ doc build [here](https://docs.ocean.dwavesys.com/en/stable/docs_preprocessing/reference/cpp.html)