### PR TITLE
Fix C++ warnings

### DIFF
--- a/dwave/preprocessing/include/dwave-preprocessing/fix_variables.hpp
+++ b/dwave/preprocessing/include/dwave-preprocessing/fix_variables.hpp
@@ -56,7 +56,7 @@ capacity_type fixQuboVariables(PosiformInfo &posiform_info, int num_bqm_variable
 
   // There may not be 1 to 1 mapping from bqm variables to posiform variables,
   // so we convert the posiform variables back to bqm variables.
-  for (int i = 0; i < fixed_variables_posiform.size(); i++) {
+  for (std::size_t i = 0; i < fixed_variables_posiform.size(); i++) {
     int bqm_variable = posiform_info.mapVariablePosiformToQubo(
         fixed_variables_posiform[i].first);
     fixed_variables.push_back(

--- a/dwave/preprocessing/include/dwave-preprocessing/helper_graph_algorithms.hpp
+++ b/dwave/preprocessing/include/dwave-preprocessing/helper_graph_algorithms.hpp
@@ -118,13 +118,13 @@ int breadthFirstSearchResidual(
     std::vector<std::vector<int>> levels;
     levels.resize(num_vertices + 1);
     level_sizes.resize(num_vertices + 1, 0);
-    for (int i = 0; i < depth_values.size(); i++) {
+    for (std::size_t i = 0; i < depth_values.size(); i++) {
       level_sizes[depth_values[i]]++;
     }
-    for (int i = 0; i < level_sizes.size(); i++) {
+    for (std::size_t i = 0; i < level_sizes.size(); i++) {
       levels[i].reserve(level_sizes[i]);
     }
-    for (int i = 0; i < depth_values.size(); i++) {
+    for (std::size_t i = 0; i < depth_values.size(); i++) {
       levels[depth_values[i]].push_back(i);
     }
     std::cout << std::endl;
@@ -132,13 +132,13 @@ int breadthFirstSearchResidual(
               << "breadth first search result starting from vertex : "
               << start_vertex << std::endl;
     std::cout << std::endl;
-    for (int i = 0; i < levels.size(); i++) {
+    for (std::size_t i = 0; i < levels.size(); i++) {
       if (!levels[i].size()) {
         continue;
       }
       std::cout << "Level " << i << " has " << levels[i].size()
                 << " vertices : " << std::endl;
-      for (int j = 0; j < levels[i].size(); j++) {
+      for (std::size_t j = 0; j < levels[i].size(); j++) {
         std::cout << levels[i][j] << " ";
       }
       std::cout << std::endl;

--- a/dwave/preprocessing/include/dwave-preprocessing/posiform_info.hpp
+++ b/dwave/preprocessing/include/dwave-preprocessing/posiform_info.hpp
@@ -236,7 +236,7 @@ PosiformInfo<BQM, coefficient_t>::PosiformInfo(const BQM &bqm) {
   // we are summing up the linear coefficients for the posiform over all the bqm
   // variables, not the posiform variables.
   _posiform_linear_sum_non_integral = 0;
-  for (int bqm_variable = 0; bqm_variable < _linear_double_biases.size();
+  for (std::size_t bqm_variable = 0; bqm_variable < _linear_double_biases.size();
        bqm_variable++) {
     _posiform_linear_sum_non_integral +=
         std::fabs(_linear_double_biases[bqm_variable]);
@@ -290,7 +290,7 @@ PosiformInfo<BQM, coefficient_t>::PosiformInfo(const BQM &bqm) {
     }
 
     _posiform_linear_sum_integral = 0; // For debugging purposes.
-    for (int bqm_variable = 0; bqm_variable < _linear_integral_biases.size();
+    for (std::size_t bqm_variable = 0; bqm_variable < _linear_integral_biases.size();
         bqm_variable++) {
       if (_linear_integral_biases[bqm_variable]) {
         _num_linear_integral_biases++;

--- a/dwave/preprocessing/include/dwave-preprocessing/posiform_info.hpp
+++ b/dwave/preprocessing/include/dwave-preprocessing/posiform_info.hpp
@@ -20,6 +20,7 @@
 #include <iostream>
 #include <limits>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 /**
@@ -210,7 +211,10 @@ PosiformInfo<BQM, coefficient_t>::PosiformInfo(const BQM &bqm) {
     if (_max_absolute_value < bqm_linear_abs) {
       _max_absolute_value = bqm_linear_abs;
     }
-    auto span = bqm.neighborhood(bqm_variable, bqm_variable + 1);
+    auto span =
+            std::make_pair(std::lower_bound(bqm.cbegin_neighborhood(bqm_variable),
+                                            bqm.cend_neighborhood(bqm_variable), bqm_variable + 1),
+                           bqm.cend_neighborhood(bqm_variable));
     _quadratic_iterators[bqm_variable] = span;
     if (span.first != span.second) {
       for (auto it_end = span.second; span.first != it_end; span.first++) {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
     "Cython>=0.29.21,<3.0",
     'numpy==1.17.3;python_version<"3.8"',  # oldest supported by dimod
     'oldest-supported-numpy;python_version>="3.8"',
-    "dimod==0.12.2",
+    "dimod==0.12.3",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dimod==0.12.2
+dimod==0.12.3
 Cython==0.29.28
 numpy==1.21.6
 

--- a/testscpp/Makefile
+++ b/testscpp/Makefile
@@ -4,7 +4,7 @@ CATCH2 := $(ROOT)/testscpp/Catch2/single_include/
 DIMOD := $(shell python -c 'import dimod; print(dimod.get_include())')
 SPDLOG := $(ROOT)/extern/spdlog/include/
 INCLUDES := -I $(SRC)/include/ -I $(DIMOD) -I $(CATCH2) -I $(SPDLOG)
-FLAGS := -std=c++17 -Wall -Wno-unknown-pragmas -Wno-sign-compare -fcompare-debug-second -O3 
+FLAGS := -std=c++17 -Wall -Wno-unknown-pragmas -fcompare-debug-second -O3 
 
 all: update test_main test_main_parallel tests tests_parallel
 

--- a/testscpp/Makefile
+++ b/testscpp/Makefile
@@ -4,7 +4,7 @@ CATCH2 := $(ROOT)/testscpp/Catch2/single_include/
 DIMOD := $(shell python -c 'import dimod; print(dimod.get_include())')
 SPDLOG := $(ROOT)/extern/spdlog/include/
 INCLUDES := -I $(SRC)/include/ -I $(DIMOD) -I $(CATCH2) -I $(SPDLOG)
-FLAGS := -std=c++17 -Wall -Wno-unknown-pragmas -Wno-sign-compare -Wno-deprecated-declarations -fcompare-debug-second -O3 
+FLAGS := -std=c++17 -Wall -Wno-unknown-pragmas -Wno-sign-compare -fcompare-debug-second -O3 
 
 all: update test_main test_main_parallel tests tests_parallel
 

--- a/testscpp/tests/test_roof_duality.cpp
+++ b/testscpp/tests/test_roof_duality.cpp
@@ -38,7 +38,7 @@ TEST_CASE("Tests for fixQuboVariables", "[roofduality]") {
 
         REQUIRE(lower_bound == -2);
         REQUIRE(fixed_vars == fixed_vars2);
-        REQUIRE(fixed_vars.size() == num_vars);
+        REQUIRE(fixed_vars.size() == static_cast<std::size_t>(num_vars));
 
         for (auto var : fixed_vars) {
             if (var.first == 2) {
@@ -129,7 +129,7 @@ TEST_CASE("Tests for fixQuboVariables", "[roofduality]") {
         fixed_vars = result.second;
 
         REQUIRE(lower_bound == 0);
-        REQUIRE(fixed_vars.size() == num_vars);
+        REQUIRE(fixed_vars.size() == static_cast<std::size_t>(num_vars));
 
         for (auto var : fixed_vars) {
             REQUIRE(var.second == 1);

--- a/testscpp/tests/test_roof_duality.cpp
+++ b/testscpp/tests/test_roof_duality.cpp
@@ -12,18 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "catch2/catch.hpp"
 #include <dimod/quadratic_model.h>
 
+#include "catch2/catch.hpp"
 #include "dwave-preprocessing/fix_variables.hpp"
 
 namespace fix_variables_ {
 
 TEST_CASE("Tests for fixQuboVariables", "[roofduality]") {
     SECTION("Test simple case") {
-        float Q [9] = {22,-4, 0,
-                        0, 0, 4,
-                        0, 0,-2};
+        float Q[9] = {22, -4, 0, 0, 0, 4, 0, 0, -2};
 
         int num_vars = 3;
         auto bqm = dimod::BinaryQuadraticModel<float, int>(Q, num_vars, dimod::Vartype::BINARY);
@@ -45,17 +43,14 @@ TEST_CASE("Tests for fixQuboVariables", "[roofduality]") {
         for (auto var : fixed_vars) {
             if (var.first == 2) {
                 REQUIRE(var.second == 1);
-            }
-            else {
+            } else {
                 REQUIRE(var.second == 0);
             }
         }
     }
 
     SECTION("Test offset") {
-        float Q [9] = {22,-4, 0,
-                        0, 0, 4,
-                        0, 0,-2};
+        float Q[9] = {22, -4, 0, 0, 0, 4, 0, 0, -2};
 
         int num_vars = 3;
         auto bqm = dimod::BinaryQuadraticModel<float, int>(Q, num_vars, dimod::Vartype::BINARY);
@@ -67,7 +62,7 @@ TEST_CASE("Tests for fixQuboVariables", "[roofduality]") {
     }
 
     SECTION("Test empty case") {
-        float Q [] = {};
+        float Q[] = {};
         auto bqm = dimod::BinaryQuadraticModel<float, int>(Q, 0, dimod::Vartype::BINARY);
 
         auto result = fixQuboVariables(bqm, true);
@@ -86,9 +81,7 @@ TEST_CASE("Tests for fixQuboVariables", "[roofduality]") {
     }
 
     SECTION("Test zero bias case") {
-        float Q [9] = {1, 0, 0,
-                       0, 0, 0,
-                       0, 0, 0};
+        float Q[9] = {1, 0, 0, 0, 0, 0, 0, 0, 0};
 
         int num_vars = 3;
         auto bqm = dimod::BinaryQuadraticModel<float, int>(Q, num_vars, dimod::Vartype::BINARY);
@@ -111,8 +104,7 @@ TEST_CASE("Tests for fixQuboVariables", "[roofduality]") {
         for (auto var : fixed_vars) {
             if (var.first == 0) {
                 REQUIRE(var.second == 0);
-            }
-            else {
+            } else {
                 // variables that didn't contribute should be set to 1
                 REQUIRE(var.second == 1);
             }
@@ -120,9 +112,8 @@ TEST_CASE("Tests for fixQuboVariables", "[roofduality]") {
     }
 
     SECTION("Test all zero bias case") {
-        float Q [4] = {0, 0, 
-                       0, 0};
-        
+        float Q[4] = {0, 0, 0, 0};
+
         int num_vars = 2;
         auto bqm = dimod::BinaryQuadraticModel<float, int>(Q, num_vars, dimod::Vartype::BINARY);
 
@@ -146,8 +137,7 @@ TEST_CASE("Tests for fixQuboVariables", "[roofduality]") {
     }
 
     SECTION("Test from previously found bug (BugSAPI1311)") {
-        float Q [4] = {2.2, -4.0,
-                         0,  2.0};
+        float Q[4] = {2.2, -4.0, 0, 2.0};
 
         int num_vars = 2;
         auto bqm = dimod::BinaryQuadraticModel<float, int>(Q, num_vars, dimod::Vartype::BINARY);
@@ -173,9 +163,7 @@ TEST_CASE("Tests for fixQuboVariables", "[roofduality]") {
 
 TEST_CASE("Tests for PosiformInfo", "[roofduality]") {
     SECTION("Test basic case") {
-        float Q [9] = {22,-4, 0,
-                        0, 0, 4,
-                        0, 0,-2};
+        float Q[9] = {22, -4, 0, 0, 0, 4, 0, 0, -2};
 
         int num_vars = 3;
         auto bqm = dimod::BinaryQuadraticModel<float, int>(Q, num_vars, dimod::Vartype::BINARY);
@@ -194,13 +182,13 @@ TEST_CASE("Tests for PosiformInfo", "[roofduality]") {
 
         auto span = posiform.getQuadratic(0);
         REQUIRE(std::distance(span.first, span.second) == 1);
-        REQUIRE(span.first->v == 1); // neighbor var
-        REQUIRE(span.first->bias == -4); // quad bias
+        REQUIRE(span.first->v == 1);      // neighbor var
+        REQUIRE(span.first->bias == -4);  // quad bias
 
         span = posiform.getQuadratic(1);
         REQUIRE(std::distance(span.first, span.second) == 1);
-        REQUIRE(span.first->v == 2); // neighbor var
-        REQUIRE(span.first->bias == 4); // quad bias
+        REQUIRE(span.first->v == 2);     // neighbor var
+        REQUIRE(span.first->bias == 4);  // quad bias
 
         span = posiform.getQuadratic(2);
         REQUIRE(std::distance(span.first, span.second) == 0);
@@ -214,18 +202,16 @@ TEST_CASE("Tests for PosiformInfo", "[roofduality]") {
     }
 
     SECTION("Test zero bias case") {
-        float Q [9] = {1, 0, 0,
-                       0, 0, 0,
-                       0, 0, 0};
+        float Q[9] = {1, 0, 0, 0, 0, 0, 0, 0, 0};
 
         int num_vars = 3;
         auto bqm = dimod::BinaryQuadraticModel<float, int>(Q, num_vars, dimod::Vartype::BINARY);
         PosiformInfo<dimod::BinaryQuadraticModel<float, int>, capacity_type> posiform(bqm);
-        
+
         REQUIRE(posiform.getNumVariables() == 1);
 
         REQUIRE(posiform.getLinear(0) > 0);
-        
+
         auto span = posiform.getQuadratic(0);
         REQUIRE(std::distance(span.first, span.second) == 0);
 


### PR DESCRIPTION
Followup on https://github.com/dwavesystems/dwave-preprocessing/pull/68. The only warnings still suppressed are the pragma ones because we may want to reintroduce OpenMP at some point.