### PR TITLE
Remove C++ Postsolver

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -331,24 +331,24 @@ workflows:
           matrix:
             parameters:
               # test the lowest and highest of each minor for the dependencies
-              dimod-version: [==0.12.2, ~=0.12.0]
+              dimod-version: [==0.12.5, ~=0.12.0]
               numpy-version: [==1.20.0, ~=1.23.0]
               python-version: *python-versions
             exclude:
               - numpy-version: ==1.20.0  # NumPy 1.20 does not support 3.10
-                dimod-version: ==0.12.2
+                dimod-version: ==0.12.5
                 python-version: 3.10.0
               - numpy-version: ==1.20.0  # NumPy 1.20 does not support 3.10
                 dimod-version: ~=0.12.0
                 python-version: 3.10.0
               - numpy-version: ==1.20.0  # NumPy 1.20 does not support 3.11
-                dimod-version: ==0.12.2
+                dimod-version: ==0.12.5
                 python-version: 3.11.0
               - numpy-version: ==1.20.0  # NumPy 1.20 does not support 3.11
                 dimod-version: ~=0.12.0
                 python-version: 3.11.0
               - numpy-version: ~=1.23.0  # NumPy 1.23 does not support 3.7
-                dimod-version: ==0.12.2
+                dimod-version: ==0.12.5
                 python-version: 3.7.9
               - numpy-version: ~=1.23.0  # NumPy 1.23 does not support 3.7
                 dimod-version: ~=0.12.0

--- a/.gitignore
+++ b/.gitignore
@@ -62,10 +62,5 @@ dwave/preprocessing/presolve/*.cpp
 dwave/preprocessing/presolve/*.html
 
 # testing stuff
-testscpp/Catch2
-testscpp/test_main
-testscpp/test_main.o
-testscpp/test_main.out
-testscpp/test_main_parallel
-testscpp/test_main_parallel.o
-testscpp/test_main_parallel.out
+testscpp/*.o
+testscpp/*.out

--- a/dwave/preprocessing/libcpp.pxd
+++ b/dwave/preprocessing/libcpp.pxd
@@ -20,9 +20,6 @@ from dimod.libcpp cimport ConstrainedQuadraticModel
 
 
 cdef extern from "dwave/presolve.h" namespace "dwave::presolve" nogil:
-    cdef cppclass Postsolver[bias_type, index_type, assignment_type]:
-        vector[T] apply[T](vector[T])
-
     cdef cppclass Presolver[bias_type, index_type, assignment_type]:
         ctypedef ConstrainedQuadraticModel[bias_type, index_type] model_type
 
@@ -32,4 +29,4 @@ cdef extern from "dwave/presolve.h" namespace "dwave::presolve" nogil:
         model_type detach_model()
         void load_default_presolvers()
         model_type& model()
-        Postsolver[bias_type, index_type, assignment_type]& postsolver()
+        vector[T] restore[T](vector[T])

--- a/dwave/preprocessing/presolve/cypresolve.pxd
+++ b/dwave/preprocessing/presolve/cypresolve.pxd
@@ -18,7 +18,7 @@
 from dimod.cyqmbase.cyqmbase_float64 cimport bias_type, index_type
 from dimod.cyvariables cimport cyVariables
 
-from dwave.preprocessing.libcpp cimport Postsolver as cppPostsolver, Presolver as cppPresolver
+from dwave.preprocessing.libcpp cimport Presolver as cppPresolver
 
 __all__ = ['cyPresolver']
 

--- a/dwave/preprocessing/presolve/cypresolve.pyx
+++ b/dwave/preprocessing/presolve/cypresolve.pyx
@@ -82,7 +82,7 @@ cdef class cyPresolver:
             for vi in range(num_variables):
                 reduced.push_back(samples[i, vi])
 
-            original = self.cpppresolver.postsolver().apply(reduced)
+            original = self.cpppresolver.restore(reduced)
 
             if original.size() != original_samples.shape[1]:
                 raise RuntimeError("unexpected reduced variables size")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
     "Cython>=0.29.21,<3.0",
     'numpy==1.17.3;python_version<"3.8"',  # oldest supported by dimod
     'oldest-supported-numpy;python_version>="3.8"',
-    "dimod==0.12.3",
+    "dimod==0.12.5",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/releasenotes/notes/c++-Presolver.restore-147bfaac7d439695.yaml
+++ b/releasenotes/notes/c++-Presolver.restore-147bfaac7d439695.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - Add C++ ``Presolver::restore()`` method for restoring samples.
+upgrade:
+  - Remove C++ ``PostSolver`` class. See `#90 <https://github.com/dwavesystems/dwave-preprocessing/issues/90>`_.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dimod==0.12.3
+dimod==0.12.5
 Cython==0.29.28
 numpy==1.21.6
 

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,6 @@ setup(
         ],
     install_requires=[
         'numpy>=1.20.0,<2.0.0',  # keep synced with circle-ci, pyproject.toml
-        'dimod>=0.12.2,<0.13.0'
+        'dimod>=0.12.5,<0.13.0'
         ],
 )

--- a/testscpp/Makefile
+++ b/testscpp/Makefile
@@ -1,30 +1,35 @@
 ROOT := ..
-SRC := $(ROOT)/dwave/preprocessing/
-CATCH2 := $(ROOT)/testscpp/Catch2/single_include/
+INCLUDE := $(ROOT)/dwave/preprocessing/include
+SRC := $(ROOT)/dwave/preprocessing/src
 DIMOD := $(shell python -c 'import dimod; print(dimod.get_include())')
+CATCH2 := $(ROOT)/testscpp/Catch2/single_include/
 SPDLOG := $(ROOT)/extern/spdlog/include/
-INCLUDES := -I $(SRC)/include/ -I $(DIMOD) -I $(CATCH2) -I $(SPDLOG)
-FLAGS := -std=c++17 -Wall -Wno-unknown-pragmas -fcompare-debug-second -O3 
+FLAGS := -std=c++17 -Wall -Wno-unknown-pragmas -fcompare-debug-second -O3
 
-all: update test_main test_main_parallel tests tests_parallel
+all: update tests
 
-tests: test_main.out
-	./test_main 
+test_main.o:
+	$(CXX) test_main.cpp -c
 
-tests_parallel: test_main_parallel.out
-	./test_main_parallel
+# Developer note: we could make this more generic, but because the package structure
+# is not at all consistent and because we have so few test files I think it's clearer to
+# just enumerate them for now.
 
-test_main: test_main.cpp
-	g++ $(FLAGS) -c test_main.cpp
-	g++ $(FLAGS) test_main.o tests/*.cpp -o test_main $(INCLUDES)
+test_presolve.o: tests/test_presolve.cpp $(INCLUDE)/dwave/presolve.h
+	$(CXX) $(FLAGS) tests/test_presolve.cpp -c -I$(CATCH2) -I$(INCLUDE) -I$(DIMOD) -I$(SPDLOG)
 
-test_main_parallel: test_main.cpp
-	g++ $(FLAGS) -fopenmp -c test_main.cpp -o test_main_parallel.o
-	g++ $(FLAGS) -fopenmp test_main_parallel.o tests/*.cpp -o test_main_parallel $(INCLUDES)
+test_roof_duality.o: tests/test_roof_duality.cpp $(wildcard $(INCLUDE)/dwave-preprocessing/*hpp)
+	$(CXX) $(FLAGS) tests/test_roof_duality.cpp -c -I$(DIMOD) -I$(CATCH2) -I$(INCLUDE)
+
+tests.out: test_main.o test_presolve.o test_roof_duality.o
+	$(CXX) $(FLAGS) test_main.o test_presolve.o test_roof_duality.o -o tests.out
+
+tests: tests.out
+	./tests.out
 
 update:
 	git submodule init
 	git submodule update
 
 clean:
-	rm -f *.out *.o test_main test_main_parallel
+	rm *.o *.out

--- a/testscpp/tests/test_presolve.cpp
+++ b/testscpp/tests/test_presolve.cpp
@@ -18,6 +18,30 @@
 
 namespace dwave {
 
+using Presolver = presolve::Presolver<double, int, double>;
+using CQM = dimod::ConstrainedQuadraticModel<double, int>;
+
+TEST_CASE("Presover construction") {
+    GIVEN("A Presolver constructed without any arguments") {
+        auto pre = Presolver();
+
+        THEN("Its held model is empty") {
+            CHECK(pre.model().num_variables() == 0);
+            CHECK(pre.model().num_constraints() == 0);
+        }
+    }
+
+    GIVEN("A Presolver constructed with an empty CQM") {
+        auto cqm = CQM();
+        auto pre = Presolver(cqm);
+
+        THEN("Its held model is empty") {
+            CHECK(pre.model().num_variables() == 0);
+            CHECK(pre.model().num_constraints() == 0);
+        }
+    }
+}
+
 SCENARIO("constrained quadratic models can be presolved") {
     GIVEN("a cqm with some trivial issues") {
         auto cqm = dimod::ConstrainedQuadraticModel<double>();

--- a/testscpp/tests/test_presolve.cpp
+++ b/testscpp/tests/test_presolve.cpp
@@ -113,7 +113,7 @@ SCENARIO("constrained quadratic models can be presolved") {
                 }
 
                 AND_WHEN("we then undo the transformation") {
-                    auto original = presolver.postsolver().apply(std::vector<int>{3});
+                    auto original = presolver.restore(std::vector<int>{3});
                     CHECK(original == std::vector<int>{3, 5, 7, 5});
                 }
             }
@@ -185,7 +185,7 @@ SCENARIO("constrained quadratic models can be presolved") {
                 }
 
                 AND_WHEN("we then undo the transformation") {
-                    auto original = presolver.postsolver().apply(std::vector<int>{0, 1, 0, 1, 0});
+                    auto original = presolver.restore(std::vector<int>{0, 1, 0, 1, 0});
                     CHECK(original == std::vector<int>{-1, +1, -1, +1, -1});
                 }
             }
@@ -224,7 +224,7 @@ SCENARIO("constrained quadratic models can be presolved") {
 
             AND_WHEN("we then undo the transformation") {
                 auto original =
-                        presolver.postsolver().apply(std::vector<int>{1, 2, 3, 4, 5, 6, 7, 8});
+                        presolver.restore(std::vector<int>{1, 2, 3, 4, 5, 6, 7, 8});
                 CHECK(original == std::vector<int>{1, 2, 3, 4, 5});
             }
         }


### PR DESCRIPTION
**This is backwards compatibility break for C++ code**

Closes https://github.com/dwavesystems/dwave-preprocessing/issues/90

This is the first of several PRs meant to refactor the C++ presolve code.