### PR TITLE
Add C++ `InvalidModelError`

### DIFF
--- a/dwave/preprocessing/include/dwave/exceptions.hpp
+++ b/dwave/preprocessing/include/dwave/exceptions.hpp
@@ -1,0 +1,26 @@
+// Copyright 2023 D-Wave Systems Inc.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+namespace dwave::presolve {
+
+struct InvalidModelError : public std::runtime_error {
+    explicit InvalidModelError(const std::string& msg);
+};
+
+}  // namespace dwave::presolve

--- a/dwave/preprocessing/include/dwave/exceptions.hpp
+++ b/dwave/preprocessing/include/dwave/exceptions.hpp
@@ -19,6 +19,8 @@
 
 namespace dwave::presolve {
 
+/// Error for models that are ill-constructed or otherwise not valid models.
+/// This is disctinct from infeasibility.
 struct InvalidModelError : public std::runtime_error {
     explicit InvalidModelError(const std::string& msg);
 };

--- a/dwave/preprocessing/src/exceptions.cpp
+++ b/dwave/preprocessing/src/exceptions.cpp
@@ -1,0 +1,21 @@
+// Copyright 2023 D-Wave Systems Inc.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include "dwave/exceptions.hpp"
+
+namespace dwave::presolve {
+
+InvalidModelError::InvalidModelError(const std::string& msg) : std::runtime_error(msg) {}
+
+}  // namespace dwave::presolve

--- a/testscpp/Makefile
+++ b/testscpp/Makefile
@@ -15,14 +15,17 @@ test_main.o:
 # is not at all consistent and because we have so few test files I think it's clearer to
 # just enumerate them for now.
 
+exceptions.o: $(INCLUDE)/dwave/exceptions.hpp $(SRC)/exceptions.cpp
+	$(CXX) $(FLAGS) $(SRC)/exceptions.cpp -c -I$(INCLUDE)
+
 test_presolve.o: tests/test_presolve.cpp $(INCLUDE)/dwave/presolve.h
 	$(CXX) $(FLAGS) tests/test_presolve.cpp -c -I$(CATCH2) -I$(INCLUDE) -I$(DIMOD) -I$(SPDLOG)
 
 test_roof_duality.o: tests/test_roof_duality.cpp $(wildcard $(INCLUDE)/dwave-preprocessing/*hpp)
 	$(CXX) $(FLAGS) tests/test_roof_duality.cpp -c -I$(DIMOD) -I$(CATCH2) -I$(INCLUDE)
 
-tests.out: test_main.o test_presolve.o test_roof_duality.o
-	$(CXX) $(FLAGS) test_main.o test_presolve.o test_roof_duality.o -o tests.out
+tests.out: test_main.o exceptions.o test_presolve.o test_roof_duality.o
+	$(CXX) $(FLAGS) test_main.o exceptions.o test_presolve.o test_roof_duality.o -o tests.out
 
 tests: tests.out
 	./tests.out


### PR DESCRIPTION
Not currently using the error anywhere, but want to set up the infrastructure for it to be used later.

~Shares the Makefile refactor commit with https://github.com/dwavesystems/dwave-preprocessing/pull/93~ edit: rebased off main