### PR TITLE
Avoid an unnecessary copy in Presolver construction

### DIFF
--- a/dwave/preprocessing/presolve/cypresolve.pxd
+++ b/dwave/preprocessing/presolve/cypresolve.pxd
@@ -24,7 +24,7 @@ __all__ = ['cyPresolver']
 
 
 cdef class cyPresolver:
-    cdef cppPresolver[bias_type, index_type, double] cpppresolver  # dev note: terrible name...
+    cdef cppPresolver[bias_type, index_type, double]* cpppresolver  # dev note: terrible name...
     
     cdef cyVariables _original_variables
     cdef Py_ssize_t _model_num_variables

--- a/releasenotes/notes/avoid-Presolve-constructor-copy-4915915d2725e4fe.yaml
+++ b/releasenotes/notes/avoid-Presolve-constructor-copy-4915915d2725e4fe.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - Improve the performance of the ``Presolver`` constructor by avoiding an unnecessary copy.
+upgrade:
+  - The wrapped C++ ``dwave::presolve::Presolver`` held by ``cyPresolver.cpppresolver`` is now stored as a pointer.


### PR DESCRIPTION
We can more-or-less halve the construction time of `Presolver` for large constrained quadratic models by avoiding an unnecessary copy.

No functional change from a user perspective.