### PR TITLE
Reimplement C++ Presolver using the PImpl pattern

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include pyproject.toml
 recursive-include dwave/preprocessing/include/ *.hpp *.h
+recursive-include dwave/preprocessing/src/ *.hpp *.cpp
 recursive-include dwave/preprocessing *.pyx *.pxd *.pyx.src
 graft extern/spdlog/include/
 include extern/spdlog/LICENSE

--- a/dwave/preprocessing/include/dwave/presolve.hpp
+++ b/dwave/preprocessing/include/dwave/presolve.hpp
@@ -14,7 +14,11 @@
 
 #pragma once
 
+#ifndef _WIN32
+// MSVC does not support std::experimental
 #include <experimental/propagate_const>
+#endif
+
 #include <memory>
 #include <utility>
 #include <vector>
@@ -58,7 +62,13 @@ class Presolver {
 
  protected:
     class PresolverImpl_;
+
+#ifndef _WIN32
     std::experimental::propagate_const<std::unique_ptr<PresolverImpl_>> impl_;
+#else
+    // MSVC does not support std::experimental
+    std::unique_ptr<PresolverImpl_> impl_;
+#endif
 };
 
 }  // namespace dwave::presolve

--- a/dwave/preprocessing/include/dwave/presolve.hpp
+++ b/dwave/preprocessing/include/dwave/presolve.hpp
@@ -1,0 +1,64 @@
+// Copyright 2023 D-Wave Systems Inc.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#pragma once
+
+#include <experimental/propagate_const>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "dimod/constrained_quadratic_model.h"
+
+namespace dwave::presolve {
+
+template <class Bias, class Index = int, class Assignment = Bias>
+class Presolver {
+ public:
+    using model_type = dimod::ConstrainedQuadraticModel<Bias, Index>;
+
+    using bias_type = Bias;
+    using index_type = Index;
+    using size_type = typename model_type::size_type;
+
+    using assignment_type = Assignment;
+
+    Presolver();
+    ~Presolver();
+
+    /// Construct a presolver from a constrained quadratic model.
+    explicit Presolver(model_type model);
+
+    /// Apply any loaded presolve techniques. Acts of the model() in-place.
+    void apply();
+
+    /// Detach the constrained quadratic model and return it.
+    /// This clears the model from the presolver.
+    model_type detach_model();
+
+    /// Load the default presolve techniques.
+    void load_default_presolvers();
+
+    /// Return a const reference to the held constrained quadratic model.
+    const model_type& model() const;
+
+    /// Return a sample of the original CQM from a sample of the reduced CQM.
+    std::vector<assignment_type> restore(std::vector<assignment_type> reduced) const;
+
+ protected:
+    class PresolverImpl_;
+    std::experimental::propagate_const<std::unique_ptr<PresolverImpl_>> impl_;
+};
+
+}  // namespace dwave::presolve

--- a/dwave/preprocessing/libcpp.pxd
+++ b/dwave/preprocessing/libcpp.pxd
@@ -19,7 +19,7 @@ from libcpp.vector cimport vector
 from dimod.libcpp cimport ConstrainedQuadraticModel
 
 
-cdef extern from "dwave/presolve.h" namespace "dwave::presolve" nogil:
+cdef extern from "dwave/presolve.hpp" namespace "dwave::presolve" nogil:
     cdef cppclass Presolver[bias_type, index_type, assignment_type]:
         ctypedef ConstrainedQuadraticModel[bias_type, index_type] model_type
 
@@ -29,4 +29,4 @@ cdef extern from "dwave/presolve.h" namespace "dwave::presolve" nogil:
         model_type detach_model()
         void load_default_presolvers()
         model_type& model()
-        vector[T] restore[T](vector[T])
+        vector[assignment_type] restore(vector[assignment_type])

--- a/dwave/preprocessing/presolve/cypresolve.pyx
+++ b/dwave/preprocessing/presolve/cypresolve.pyx
@@ -1,3 +1,5 @@
+# distutils: sources = dwave/preprocessing/src/presolve.cpp
+
 # Copyright 2022 D-Wave Systems Inc.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");

--- a/dwave/preprocessing/src/presolve.cpp
+++ b/dwave/preprocessing/src/presolve.cpp
@@ -61,8 +61,13 @@ std::vector<Assignment> Presolver<Bias, Index, Assignment>::restore(
     return impl_->restore(reduced);
 }
 
-// If we start seeing pickup on this library, we can build other numeric
-// combinations. But for now, this is the only CQM combo that dimod distributes.
+// There are many other combinations that we could expose, but since dimod
+// only exposes CQM<float64, int32> via the Cython interface we only do the
+// minimum here for now.
+// We do need to do both int and long because on Cython for MSVC int32 is an
+// alias for long, so if we explicitly instantiate anything but long MSVC gets
+// confused.
 template class Presolver<double, int, double>;
+template class Presolver<double, long, double>;
 
 }  // namespace dwave::presolve

--- a/dwave/preprocessing/src/presolve.cpp
+++ b/dwave/preprocessing/src/presolve.cpp
@@ -1,0 +1,68 @@
+// Copyright 2023 D-Wave Systems Inc.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include "dwave/presolve.hpp"
+
+#include "presolveimpl.hpp"
+
+namespace dwave::presolve {
+
+template <class Bias, class Index, class Assignment>
+class Presolver<Bias, Index, Assignment>::PresolverImpl_
+        : public PresolverImpl<Bias, Index, Assignment> {
+    using PresolverImpl<Bias, Index, Assignment>::PresolverImpl;  // inherit constructors as well
+};
+
+template <class Bias, class Index, class Assignment>
+Presolver<Bias, Index, Assignment>::Presolver() : impl_(new PresolverImpl_) {}
+
+template <class Bias, class Index, class Assignment>
+Presolver<Bias, Index, Assignment>::~Presolver() = default;
+
+template <class Bias, class Index, class Assignment>
+Presolver<Bias, Index, Assignment>::Presolver(dimod::ConstrainedQuadraticModel<Bias, Index> model)
+        : impl_(std::make_unique<PresolverImpl_>(std::move(model))) {}
+
+template <class Bias, class Index, class Assignment>
+void Presolver<Bias, Index, Assignment>::apply() {
+    impl_->apply();
+}
+
+template <class Bias, class Index, class Assignment>
+dimod::ConstrainedQuadraticModel<Bias, Index> Presolver<Bias, Index, Assignment>::detach_model() {
+    return impl_->detach_model();
+}
+
+template <class Bias, class Index, class Assignment>
+void Presolver<Bias, Index, Assignment>::load_default_presolvers() {
+    impl_->load_default_presolvers();
+}
+
+template <class Bias, class Index, class Assignment>
+const dimod::ConstrainedQuadraticModel<Bias, Index>& Presolver<Bias, Index, Assignment>::model()
+        const {
+    return impl_->model();
+}
+
+template <class Bias, class Index, class Assignment>
+std::vector<Assignment> Presolver<Bias, Index, Assignment>::restore(
+        std::vector<Assignment> reduced) const {
+    return impl_->restore(reduced);
+}
+
+// If we start seeing pickup on this library, we can build other numeric
+// combinations. But for now, this is the only CQM combo that dimod distributes.
+template class Presolver<double, int, double>;
+
+}  // namespace dwave::presolve

--- a/dwave/preprocessing/src/presolveimpl.hpp
+++ b/dwave/preprocessing/src/presolveimpl.hpp
@@ -20,14 +20,13 @@
 #include <utility>
 #include <vector>
 
-#include "spdlog/spdlog.h"
 #include "dimod/constrained_quadratic_model.h"
 
 namespace dwave {
 namespace presolve {
 
 template <class Bias, class Index = int, class Assignment = double>
-class Presolver {
+class PresolverImpl {
  public:
     using model_type = dimod::ConstrainedQuadraticModel<Bias, Index>;
 
@@ -38,10 +37,10 @@ class Presolver {
     using assignment_type = Assignment;
 
     /// Default constructor.
-    Presolver();
+    PresolverImpl();
 
     /// Construct a presolver from a constrained quadratic model.
-    explicit Presolver(model_type model);
+    explicit PresolverImpl(model_type model);
 
     /// Apply any loaded presolve techniques. Acts of the model() in-place.
     void apply();
@@ -604,15 +603,15 @@ class Presolver {
 };
 
 template <class bias_type, class index_type, class assignment_type>
-Presolver<bias_type, index_type, assignment_type>::Presolver()
+PresolverImpl<bias_type, index_type, assignment_type>::PresolverImpl()
         : model_(), default_techniques_(false), detached_(false) {}
 
 template <class bias_type, class index_type, class assignment_type>
-Presolver<bias_type, index_type, assignment_type>::Presolver(model_type model)
+PresolverImpl<bias_type, index_type, assignment_type>::PresolverImpl(model_type model)
         : model_(std::move(model)), default_techniques_(), detached_(false) {}
 
 template <class bias_type, class index_type, class assignment_type>
-void Presolver<bias_type, index_type, assignment_type>::apply() {
+void PresolverImpl<bias_type, index_type, assignment_type>::apply() {
     if (detached_) throw std::logic_error("model has been detached, presolver is no longer valid");
 
     // If no techniques have been loaded, return early.
@@ -661,19 +660,19 @@ void Presolver<bias_type, index_type, assignment_type>::apply() {
 
 template <class bias_type, class index_type, class assignment_type>
 dimod::ConstrainedQuadraticModel<bias_type, index_type>
-Presolver<bias_type, index_type, assignment_type>::detach_model() {
+PresolverImpl<bias_type, index_type, assignment_type>::detach_model() {
     detached_ = true;
     return model_.detach_model();
 }
 
 template <class bias_type, class index_type, class assignment_type>
-void Presolver<bias_type, index_type, assignment_type>::load_default_presolvers() {
+void PresolverImpl<bias_type, index_type, assignment_type>::load_default_presolvers() {
     default_techniques_ = true;
 }
 
 template <class bias_type, class index_type, class assignment_type>
 const dimod::ConstrainedQuadraticModel<bias_type, index_type>&
-Presolver<bias_type, index_type, assignment_type>::model() const {
+PresolverImpl<bias_type, index_type, assignment_type>::model() const {
     return model_.model();
 }
 

--- a/releasenotes/notes/presolve-pimpl-00987944df99570e.yaml
+++ b/releasenotes/notes/presolve-pimpl-00987944df99570e.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Reimplement the C++ ``Presolver`` using the PImpl pattern. This will make
+    it easier to maintain binary compatibility going forward.
+    See `#89 <https://github.com/dwavesystems/dwave-preprocessing/issues/89>`_.
+upgrade:
+  - The C++ ``Presolver`` no longer has a header-only implementation.

--- a/testscpp/Makefile
+++ b/testscpp/Makefile
@@ -18,14 +18,17 @@ test_main.o:
 exceptions.o: $(INCLUDE)/dwave/exceptions.hpp $(SRC)/exceptions.cpp
 	$(CXX) $(FLAGS) $(SRC)/exceptions.cpp -c -I$(INCLUDE)
 
-test_presolve.o: tests/test_presolve.cpp $(INCLUDE)/dwave/presolve.h
+presolve.o: $(INCLUDE)/dwave/presolve.hpp $(SRC)/presolve.cpp $(SRC)/presolveimpl.hpp
+	$(CXX) $(FLAGS) $(SRC)/presolve.cpp -c -I$(INCLUDE) -I$(SRC) -I$(DIMOD)
+
+test_presolve.o: tests/test_presolve.cpp $(INCLUDE)/dwave/presolve.hpp 
 	$(CXX) $(FLAGS) tests/test_presolve.cpp -c -I$(CATCH2) -I$(INCLUDE) -I$(DIMOD) -I$(SPDLOG)
 
 test_roof_duality.o: tests/test_roof_duality.cpp $(wildcard $(INCLUDE)/dwave-preprocessing/*hpp)
 	$(CXX) $(FLAGS) tests/test_roof_duality.cpp -c -I$(DIMOD) -I$(CATCH2) -I$(INCLUDE)
 
-tests.out: test_main.o exceptions.o test_presolve.o test_roof_duality.o
-	$(CXX) $(FLAGS) test_main.o exceptions.o test_presolve.o test_roof_duality.o -o tests.out
+tests.out: test_main.o exceptions.o presolve.o test_presolve.o test_roof_duality.o
+	$(CXX) $(FLAGS) test_main.o exceptions.o presolve.o test_presolve.o test_roof_duality.o -o tests.out
 
 tests: tests.out
 	./tests.out
@@ -35,4 +38,4 @@ update:
 	git submodule update
 
 clean:
-	rm *.o *.out
+	rm -f *.o *.out

--- a/testscpp/tests/test_presolve.cpp
+++ b/testscpp/tests/test_presolve.cpp
@@ -14,7 +14,7 @@
 
 #include "catch2/catch.hpp"
 #include "dimod/constrained_quadratic_model.h"
-#include "dwave/presolve.h"
+#include "dwave/presolve.hpp"
 
 namespace dwave {
 
@@ -113,8 +113,8 @@ SCENARIO("constrained quadratic models can be presolved") {
                 }
 
                 AND_WHEN("we then undo the transformation") {
-                    auto original = presolver.restore(std::vector<int>{3});
-                    CHECK(original == std::vector<int>{3, 5, 7, 5});
+                    auto original = presolver.restore(std::vector<double>{3});
+                    CHECK(original == std::vector<double>{3, 5, 7, 5});
                 }
             }
 
@@ -185,8 +185,8 @@ SCENARIO("constrained quadratic models can be presolved") {
                 }
 
                 AND_WHEN("we then undo the transformation") {
-                    auto original = presolver.restore(std::vector<int>{0, 1, 0, 1, 0});
-                    CHECK(original == std::vector<int>{-1, +1, -1, +1, -1});
+                    auto original = presolver.restore(std::vector<double>{0, 1, 0, 1, 0});
+                    CHECK(original == std::vector<double>{-1, +1, -1, +1, -1});
                 }
             }
         }
@@ -224,8 +224,8 @@ SCENARIO("constrained quadratic models can be presolved") {
 
             AND_WHEN("we then undo the transformation") {
                 auto original =
-                        presolver.restore(std::vector<int>{1, 2, 3, 4, 5, 6, 7, 8});
-                CHECK(original == std::vector<int>{1, 2, 3, 4, 5});
+                        presolver.restore(std::vector<double>{1, 2, 3, 4, 5, 6, 7, 8});
+                CHECK(original == std::vector<double>{1, 2, 3, 4, 5});
             }
         }
     }


### PR DESCRIPTION
**This is a backwards compatibility break.**

The immediate benefit is that we'll be much less likely to break binary compatibility when we make implementation changes going forward.
Another benefit is compilation time.
Finally, in the future, we can make the PresolverImpl class much more testable because we can expose more methods without them being user-facing.

Closes https://github.com/dwavesystems/dwave-preprocessing/issues/89