### PR TITLE
Refactor presolve methods

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -333,24 +333,24 @@ workflows:
           matrix:
             parameters:
               # test the lowest and highest of each minor for the dependencies
-              dimod-version: [==0.12.5, ~=0.12.0]
+              dimod-version: [==0.12.6, ~=0.12.0]
               numpy-version: [==1.20.0, ~=1.23.0]
               python-version: *python-versions
             exclude:
               - numpy-version: ==1.20.0  # NumPy 1.20 does not support 3.10
-                dimod-version: ==0.12.5
+                dimod-version: ==0.12.6
                 python-version: 3.10.0
               - numpy-version: ==1.20.0  # NumPy 1.20 does not support 3.10
                 dimod-version: ~=0.12.0
                 python-version: 3.10.0
               - numpy-version: ==1.20.0  # NumPy 1.20 does not support 3.11
-                dimod-version: ==0.12.5
+                dimod-version: ==0.12.6
                 python-version: 3.11.0
               - numpy-version: ==1.20.0  # NumPy 1.20 does not support 3.11
                 dimod-version: ~=0.12.0
                 python-version: 3.11.0
               - numpy-version: ~=1.23.0  # NumPy 1.23 does not support 3.7
-                dimod-version: ==0.12.5
+                dimod-version: ==0.12.6
                 python-version: 3.7.9
               - numpy-version: ~=1.23.0  # NumPy 1.23 does not support 3.7
                 dimod-version: ~=0.12.0

--- a/dwave/preprocessing/include/dwave/flags.hpp
+++ b/dwave/preprocessing/include/dwave/flags.hpp
@@ -27,7 +27,17 @@ enum Feasibility {
 enum TechniqueFlags : std::uint64_t {
     None = 0,
 
-    // todo: individual technique flags
+    /// Remove redundant constraints.
+    /// See Achterberg et al., section 3.1.
+    RemoveRedundantConstraints = 1 << 0,
+
+    /// Remove small biases from the objective and constraints.
+    /// See Achterberg et al., section 3.1.
+    RemoveSmallBiases = 1 << 1,
+
+    /// Use constraints to tighten the bounds on variables.
+    /// See Achterberg et al., section 3.2.
+    DomainPropagation = 1 << 2,
 
     All = 0xffffffffffffffffu,
 

--- a/dwave/preprocessing/include/dwave/presolve.hpp
+++ b/dwave/preprocessing/include/dwave/presolve.hpp
@@ -52,6 +52,8 @@ class Presolver {
     /// This clears the model from the presolver.
     model_type detach_model();
 
+    const Feasibility& feasibility() const;
+
     /// Load the default presolve techniques.
     void load_default_presolvers();
 

--- a/dwave/preprocessing/libcpp.pxd
+++ b/dwave/preprocessing/libcpp.pxd
@@ -22,7 +22,10 @@ cdef extern from "dwave/exceptions.hpp" namespace "dwave::presolve" nogil:
     pass
 
 cdef extern from "dwave/flags.hpp" namespace "dwave::presolve" nogil:
-    pass
+    enum Feasibility:
+        Unknown,
+        Infeasible,
+        Feasible
 
 cdef extern from "dwave/presolve.hpp" namespace "dwave::presolve" nogil:
     cdef cppclass Presolver[bias_type, index_type, assignment_type]:
@@ -32,6 +35,7 @@ cdef extern from "dwave/presolve.hpp" namespace "dwave::presolve" nogil:
         Presolver(model_type)
         void apply() except+
         model_type detach_model()
+        const Feasibility& feasibility() const
         void load_default_presolvers()
         model_type& model()
         vector[assignment_type] restore(vector[assignment_type])

--- a/dwave/preprocessing/presolve/cypresolve.pyx
+++ b/dwave/preprocessing/presolve/cypresolve.pyx
@@ -27,6 +27,8 @@ from dimod.libcpp cimport ConstrainedQuadraticModel as cppConstrainedQuadraticMo
 from dimod.constrained.cyconstrained cimport cyConstrainedQuadraticModel, make_cqm
 from dimod.cyutilities cimport ConstNumeric
 
+from dwave.preprocessing.libcpp cimport Feasibility as cppFeasibility
+
 # We want to establish a relationship between presolveimpl.hpp and this file, so that
 # changes to presolveimpl.hpp will trigger a rebuild.
 cdef extern from "../src/presolveimpl.hpp" namespace "dwave::presolve" nogil:
@@ -60,6 +62,9 @@ cdef class cyPresolver:
         """Apply any loaded presolve techniques to the held constrained quadratic model."""
         self.cpppresolver.apply()
         self._model_num_variables = self.cpppresolver.model().num_variables()
+
+        if self.cpppresolver.feasibility() == cppFeasibility.Infeasible:
+            raise RuntimeError("infeasible")
 
     def clear_model(self):
         """Clear the held constrained quadratic model. This is useful to save memory."""

--- a/dwave/preprocessing/src/presolve.cpp
+++ b/dwave/preprocessing/src/presolve.cpp
@@ -46,6 +46,11 @@ dimod::ConstrainedQuadraticModel<Bias, Index> Presolver<Bias, Index, Assignment>
 }
 
 template <class Bias, class Index, class Assignment>
+const Feasibility& Presolver<Bias, Index, Assignment>::feasibility() const {
+    return impl_->feasibility();
+}
+
+template <class Bias, class Index, class Assignment>
 void Presolver<Bias, Index, Assignment>::load_default_presolvers() {
     impl_->techniques = TechniqueFlags::Default;
 }

--- a/dwave/preprocessing/src/presolveimpl.hpp
+++ b/dwave/preprocessing/src/presolveimpl.hpp
@@ -378,7 +378,7 @@ class PresolverImpl {
             loop_changes = false;
 
             if (techniques & TechniqueFlags::RemoveSmallBiases) {
-                changes |= technique_remove_small_biases(model_.objective());
+                loop_changes |= technique_remove_small_biases(model_.objective());
                 for (auto& constraint : model_.constraints()) {
                     loop_changes |= technique_remove_small_biases(constraint);
                 }

--- a/dwave/preprocessing/src/presolveimpl.hpp
+++ b/dwave/preprocessing/src/presolveimpl.hpp
@@ -850,6 +850,12 @@ class PresolverImpl {
         void fix_variables(typename std::vector<index_type>::iterator first,
                            typename std::vector<index_type>::iterator last,
                            typename std::vector<assignment_type>::iterator assignment) {
+            // short circuit in the case there's nothing to fix, thereby avoiding
+            // an expensive copy.
+            if (first == last) {
+                return;
+            }
+
             // track the changes as if we had applied them one-by-one 
             auto vit = first;
             auto ait = assignment;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
     "Cython>=0.29.21,<3.0",
     'numpy==1.17.3;python_version<"3.8"',  # oldest supported by dimod
     'oldest-supported-numpy;python_version>="3.8"',
-    "dimod==0.12.5",
+    "dimod==0.12.6",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dimod==0.12.5
+dimod==0.12.6
 Cython==0.29.28
 numpy==1.21.6
 

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,6 @@ setup(
         ],
     install_requires=[
         'numpy>=1.20.0,<2.0.0',  # keep synced with circle-ci, pyproject.toml
-        'dimod>=0.12.5,<0.13.0'
+        'dimod>=0.12.6,<0.13.0'
         ],
 )

--- a/tests/test_presolve.py
+++ b/tests/test_presolve.py
@@ -267,38 +267,6 @@ class TestPresolver(unittest.TestCase):
         self.assertEqual(cqm.upper_bound(0), +5)
         self.assertEqual(cqm.num_constraints(), 0)
 
-    def test_small_biases(self):
-        i, j, k, l = dimod.Reals('ijkl')
-
-        cqm = dimod.ConstrainedQuadraticModel()
-        cqm.set_objective(i + j + k + l)
-        cqm.add_constraint(1e-9 * i + 1e-8 * j + k <= 100)
-        cqm.add_constraint(i + j + 1e-10 * k + 1e-11 * l <= 100)
-
-        cqm.set_lower_bound('i', 1e10)
-        cqm.set_upper_bound('i', 1e10 + 1)
-        cqm.set_lower_bound('j', 1e10)
-        cqm.set_upper_bound('j', 1e10 + 1)
-        cqm.set_lower_bound('k', -20)
-        cqm.set_upper_bound('k', 0)
-
-        presolver = Presolver(cqm)
-        presolver.load_default_presolvers()
-        presolver.apply()
-        updated_cqm = presolver.copy_model()
-        new = updated_cqm.constraints
-
-        self.assertEqual(new[0].lhs.get_linear(0), 0)
-        self.assertEqual(new[0].lhs.get_linear(1), 1e-8)
-        self.assertEqual(new[0].lhs.get_linear(2), 1)
-        self.assertEqual(new[0].rhs, 100 - 1e-9 * 1e10)
-
-        self.assertEqual(new[1].lhs.get_linear(0), 1)
-        self.assertEqual(new[1].lhs.get_linear(1), 1)
-        self.assertEqual(new[1].lhs.get_linear(2), 0)
-        self.assertEqual(new[1].lhs.get_linear(3), 0)
-        self.assertEqual(new[1].rhs, 100 - 1e-10 * (-20))
-
     def test_domain_propagation(self):
         i, j, k, l, m, n, o, p = dimod.Reals('ijklmnop')
 

--- a/testscpp/tests/test_presolve.cpp
+++ b/testscpp/tests/test_presolve.cpp
@@ -324,9 +324,8 @@ SCENARIO("constrained quadratic models can be presolved") {
                 presolver.load_default_presolvers();
                 presolver.apply();
 
-                THEN("the constraint is still marked as discrete") {
-                    REQUIRE(presolver.model().num_constraints() == 1);
-                    CHECK(!presolver.model().constraint_ref(0).marked_discrete());
+                THEN("the constraint is removed") {
+                    REQUIRE(presolver.model().num_constraints() == 0);
                 }
             }
         }

--- a/testscpp/tests/test_presolveimpl.cpp
+++ b/testscpp/tests/test_presolveimpl.cpp
@@ -39,6 +39,27 @@ TEST_CASE("Test construction", "[presolve][impl]") {
     }
 }
 
+TEST_CASE("Test apply()", "[presolve][impl]") {
+    SECTION("A CQM with a single self-loop") {
+        auto cqm = ConstrainedQuadraticModel();
+        auto i = cqm.add_variable(dimod::Vartype::INTEGER);
+        auto c = cqm.add_linear_constraint({}, {}, dimod::Sense::LE, 0);
+        cqm.constraint_ref(c).set_quadratic(i, i, 1);
+
+        WHEN("We call apply()") {
+            auto pre = PresolverImpl(cqm);
+            pre.techniques = presolve::TechniqueFlags::DomainPropagation;
+            pre.apply();
+
+            THEN("The model is not infeasible") {
+                CHECK(pre.feasibility() != presolve::Feasibility::Infeasible);
+                CHECK(pre.model().num_variables() == 2.0);
+                CHECK(pre.model().num_constraints() == 2.0);
+            }
+        }
+    }
+}
+
 TEST_CASE("Test normalization_fix_bounds", "[presolve][impl]") {
     GIVEN("A CQM with valid bounds") {
         auto cqm = ConstrainedQuadraticModel();
@@ -338,6 +359,460 @@ TEST_CASE("Test normalization_spin_to_binary", "[presolve][impl]") {
                       cqm.objective.energy(spin_sample.begin()));
                 CHECK(pre.model().constraint_ref(c).energy(bin_sample.begin()) ==
                       cqm.constraint_ref(c).energy(spin_sample.begin()));
+            }
+        }
+    }
+}
+
+TEST_CASE("Test technique_domain_propagation", "[presolve][impl]") {
+    GIVEN("An empty constraint") {
+        auto cqm = ConstrainedQuadraticModel();
+        cqm.add_constraint();
+
+        THEN("Domain propagation does nothing") {
+            auto pre = PresolverImpl(cqm);
+            CHECK(!pre.technique_domain_propagation(pre.model().constraint_ref(0)));
+        }
+    }
+
+    GIVEN("A CQM with a single REAL variable in [-100, 200]") {
+        auto cqm = ConstrainedQuadraticModel();
+        auto v = cqm.add_variable(dimod::Vartype::REAL, -100, +200);
+
+        AND_GIVEN("A v <= -105 constraint that makes the model infeasible") {
+            auto c = cqm.add_linear_constraint({v}, {1}, dimod::Sense::LE, -105);
+
+            WHEN("We apply domain propagation") {
+                auto pre = PresolverImpl(cqm);
+                CHECK(!pre.technique_domain_propagation(pre.model().constraint_ref(c)));
+
+                THEN("The bounds aren't changed but the model is marked infeasible") {
+                    CHECK(pre.model().lower_bound(v) == -100.0);
+                    CHECK(pre.model().upper_bound(v) == +200.0);
+                    CHECK(pre.feasibility() == presolve::Feasibility::Infeasible);
+                }
+            }
+        }
+
+        AND_GIVEN("A v >= 201 constraint that makes the model infeasible") {
+            auto c = cqm.add_linear_constraint({v}, {1}, dimod::Sense::GE, 201);
+
+            WHEN("We apply domain propagation") {
+                auto pre = PresolverImpl(cqm);
+                CHECK(!pre.technique_domain_propagation(pre.model().constraint_ref(c)));
+
+                THEN("The bounds aren't changed but the model is marked infeasible") {
+                    CHECK(pre.model().lower_bound(v) == -100.0);
+                    CHECK(pre.model().upper_bound(v) == +200.0);
+                    CHECK(pre.feasibility() == presolve::Feasibility::Infeasible);
+                }
+            }
+        }
+
+        AND_GIVEN("A v == 201 constraint that makes the model infeasible") {
+            auto c = cqm.add_linear_constraint({v}, {1}, dimod::Sense::EQ, 201);
+
+            WHEN("We apply domain propagation") {
+                auto pre = PresolverImpl(cqm);
+                CHECK(!pre.technique_domain_propagation(pre.model().constraint_ref(c)));
+
+                THEN("The bounds aren't changed but the model is marked infeasible") {
+                    CHECK(pre.model().lower_bound(v) == -100.0);
+                    CHECK(pre.model().upper_bound(v) == +200.0);
+                    CHECK(pre.feasibility() == presolve::Feasibility::Infeasible);
+                }
+            }
+        }
+
+        AND_GIVEN("A v <= 3 constraint") {
+            auto c = cqm.add_linear_constraint({v}, {1}, dimod::Sense::LE, 3);
+
+            WHEN("We apply domain propagation") {
+                auto pre = PresolverImpl(cqm);
+                CHECK(pre.technique_domain_propagation(pre.model().constraint_ref(c)));
+
+                THEN("The upper bound is tightened") {
+                    CHECK(pre.model().lower_bound(v) == -100.0);
+                    CHECK(pre.model().upper_bound(v) == 3.0);
+                    CHECK(pre.feasibility() == presolve::Feasibility::Unknown);
+                }
+            }
+        }
+
+        AND_GIVEN("A v <= 203 constraint") {
+            auto c = cqm.add_linear_constraint({v}, {1}, dimod::Sense::LE, 203);
+
+            WHEN("We apply domain propagation") {
+                auto pre = PresolverImpl(cqm);
+                CHECK(!pre.technique_domain_propagation(pre.model().constraint_ref(c)));
+
+                THEN("The bounds don't change") {
+                    CHECK(pre.model().lower_bound(v) == -100.0);
+                    CHECK(pre.model().upper_bound(v) == +200.0);
+                    CHECK(pre.feasibility() == presolve::Feasibility::Unknown);
+                }
+            }
+        }
+
+        AND_GIVEN("A 6*v >= 30 constraint") {
+            auto c = cqm.add_linear_constraint({v}, {6}, dimod::Sense::GE, 30);
+
+            // because of normalization we should never need to handle this case,
+            // but it's a nice test case so no harm
+            WHEN("We apply domain propagation") {
+                auto pre = PresolverImpl(cqm);
+                CHECK(pre.technique_domain_propagation(pre.model().constraint_ref(c)));
+
+                THEN("The lower bound is tightened") {
+                    CHECK(pre.model().lower_bound(v) == 5.0);
+                    CHECK(pre.model().upper_bound(v) == 200.0);
+                    CHECK(pre.feasibility() == presolve::Feasibility::Unknown);
+                }
+            }
+
+            WHEN("We normalize and then apply domain propagation") {
+                auto pre = PresolverImpl(cqm);
+                CHECK(pre.normalize());
+                CHECK(pre.technique_domain_propagation(pre.model().constraint_ref(c)));
+
+                THEN("The lower bound is tightened") {
+                    CHECK(pre.model().lower_bound(v) == 5.0);
+                    CHECK(pre.model().upper_bound(v) == 200.0);
+                    CHECK(pre.feasibility() == presolve::Feasibility::Unknown);
+                }
+            }
+        }
+
+        AND_GIVEN("A v >= -105 constraint") {
+            auto c = cqm.add_linear_constraint({v}, {1}, dimod::Sense::GE, -105);
+
+            // because of normalization we should never need to handle this case,
+            // but it's a nice test case so no harm
+            WHEN("We apply domain propagation") {
+                auto pre = PresolverImpl(cqm);
+                CHECK(!pre.technique_domain_propagation(pre.model().constraint_ref(c)));
+
+                THEN("The bounds don't change") {
+                    CHECK(pre.model().lower_bound(v) == -100);
+                    CHECK(pre.model().upper_bound(v) == 200.0);
+                    CHECK(pre.feasibility() == presolve::Feasibility::Unknown);
+                }
+            }
+
+            WHEN("We normalize and then apply domain propagation") {
+                auto pre = PresolverImpl(cqm);
+                CHECK(pre.normalize());
+                CHECK(!pre.technique_domain_propagation(pre.model().constraint_ref(c)));
+
+                THEN("The bounds don't change") {
+                    CHECK(pre.model().lower_bound(v) == -100);
+                    CHECK(pre.model().upper_bound(v) == 200.0);
+                    CHECK(pre.feasibility() == presolve::Feasibility::Unknown);
+                }
+            }
+        }
+
+        AND_GIVEN("A 6*v == 30 constraint") {
+            auto c = cqm.add_linear_constraint({v}, {6}, dimod::Sense::EQ, 30);
+
+            WHEN("We apply domain propagation") {
+                auto pre = PresolverImpl(cqm);
+                CHECK(pre.technique_domain_propagation(pre.model().constraint_ref(c)));
+
+                THEN("The upper and lower bound are updated") {
+                    CHECK(pre.model().lower_bound(v) == 5.0);
+                    CHECK(pre.model().upper_bound(v) == 5.0);
+                    CHECK(pre.feasibility() == presolve::Feasibility::Unknown);
+                }
+            }
+        }
+
+        AND_GIVEN("A -6*v == 30 constraint") {
+            auto c = cqm.add_linear_constraint({v}, {-6}, dimod::Sense::EQ, 30);
+
+            WHEN("We apply domain propagation") {
+                auto pre = PresolverImpl(cqm);
+                CHECK(pre.technique_domain_propagation(pre.model().constraint_ref(c)));
+
+                THEN("The upper and lower bound are updated") {
+                    CHECK(pre.model().lower_bound(v) == -5.0);
+                    CHECK(pre.model().upper_bound(v) == -5.0);
+                    CHECK(pre.feasibility() == presolve::Feasibility::Unknown);
+                }
+            }
+        }
+    }
+
+    GIVEN("A CQM with a binary variable x and a continuous variable v") {
+        auto cqm = ConstrainedQuadraticModel();
+        auto x = cqm.add_variable(dimod::Vartype::BINARY);
+        auto v = cqm.add_variable(dimod::Vartype::REAL, -50, +50);
+
+        AND_GIVEN("A 2x + 4v <= 20 constraint") {
+            auto c = cqm.add_linear_constraint({x, v}, {2, 4}, dimod::Sense::LE, 20);
+
+            WHEN("We apply domain propagation") {
+                auto pre = PresolverImpl(cqm);
+                CHECK(pre.technique_domain_propagation(pre.model().constraint_ref(c)));
+
+                THEN("The upper bound of v is updated") {
+                    CHECK(pre.model().lower_bound(x) == 0.0);
+                    CHECK(pre.model().upper_bound(x) == 1.0);
+                    CHECK(pre.model().lower_bound(v) == -50.0);
+                    CHECK(pre.model().upper_bound(v) == 5.0);
+                    CHECK(pre.feasibility() == presolve::Feasibility::Unknown);
+                }
+            }
+        }
+
+        AND_GIVEN("A -2x + 4v <= 20 constraint") {
+            auto c = cqm.add_linear_constraint({x, v}, {-2, 4}, dimod::Sense::LE, 20);
+
+            WHEN("We apply domain propagation") {
+                auto pre = PresolverImpl(cqm);
+                CHECK(pre.technique_domain_propagation(pre.model().constraint_ref(c)));
+
+                THEN("The upper bound of v is updated") {
+                    CHECK(pre.model().lower_bound(x) == 0.0);
+                    CHECK(pre.model().upper_bound(x) == 1.0);
+                    CHECK(pre.model().lower_bound(v) == -50.0);
+                    CHECK(pre.model().upper_bound(v) == 5.5);
+                    CHECK(pre.feasibility() == presolve::Feasibility::Unknown);
+                }
+            }
+        }
+    }
+
+    GIVEN("A CQM with a binary variable x and an integer variable v") {
+        auto cqm = ConstrainedQuadraticModel();
+        auto x = cqm.add_variable(dimod::Vartype::BINARY);
+        auto v = cqm.add_variable(dimod::Vartype::INTEGER, -50, +50);
+
+        AND_GIVEN("A 2x + 4v <= 20 constraint") {
+            auto c = cqm.add_linear_constraint({x, v}, {2, 4}, dimod::Sense::LE, 20);
+
+            WHEN("We apply domain propagation") {
+                auto pre = PresolverImpl(cqm);
+                CHECK(pre.technique_domain_propagation(pre.model().constraint_ref(c)));
+
+                THEN("The upper bound of v is updated") {
+                    CHECK(pre.model().lower_bound(x) == 0.0);
+                    CHECK(pre.model().upper_bound(x) == 1.0);
+                    CHECK(pre.model().lower_bound(v) == -50.0);
+                    CHECK(pre.model().upper_bound(v) == 5.0);
+                    CHECK(pre.feasibility() == presolve::Feasibility::Unknown);
+                }
+            }
+        }
+
+        AND_GIVEN("A -2x + 4v <= 20 constraint") {
+            auto c = cqm.add_linear_constraint({x, v}, {-2, 4}, dimod::Sense::LE, 20);
+
+            WHEN("We apply domain propagation") {
+                auto pre = PresolverImpl(cqm);
+                CHECK(pre.technique_domain_propagation(pre.model().constraint_ref(c)));
+
+                THEN("The upper bound of v is updated") {
+                    CHECK(pre.model().lower_bound(x) == 0.0);
+                    CHECK(pre.model().upper_bound(x) == 1.0);
+                    CHECK(pre.model().lower_bound(v) == -50.0);
+                    CHECK(pre.model().upper_bound(v) == 5.0);  // floor(5.5)
+                    CHECK(pre.feasibility() == presolve::Feasibility::Unknown);
+                }
+            }
+        }
+    }
+
+    GIVEN("A CQM with an equality constraint over two binary variables") {
+        auto cqm = ConstrainedQuadraticModel();
+        auto x = cqm.add_variable(dimod::Vartype::BINARY);
+        auto y = cqm.add_variable(dimod::Vartype::BINARY);
+        auto c = cqm.add_linear_constraint({x, y}, {1, -1}, dimod::Sense::EQ, 0);
+
+        WHEN("We apply domain propagation") {
+            auto pre = PresolverImpl(cqm);
+            CHECK(!pre.technique_domain_propagation(pre.model().constraint_ref(c)));
+
+            THEN("nothing happens") {
+                CHECK(pre.model().num_variables() == 2.0);
+                CHECK(pre.model().constraint_ref(c).linear(x) == 1.0);
+                CHECK(pre.model().constraint_ref(c).linear(y) == -1.0);
+                CHECK(pre.feasibility() != presolve::Feasibility::Infeasible);
+            }
+        }
+    }
+
+    GIVEN("A CQM with two cont. variables and two <= constraints that can strengthen eachother") {
+        auto cqm = ConstrainedQuadraticModel();
+        auto a = cqm.add_variable(dimod::Vartype::REAL);
+        auto b = cqm.add_variable(dimod::Vartype::REAL);
+        auto c0 = cqm.add_linear_constraint({a, b}, {1, -2}, dimod::Sense::LE, -100);
+        auto c1 = cqm.add_linear_constraint({a, b}, {-2, 1}, dimod::Sense::LE, -100);
+
+        auto pre = PresolverImpl(cqm);
+
+        WHEN("we apply domain propagation to the a - 2b <= -100 constraint") {
+            pre.technique_domain_propagation(pre.model().constraint_ref(c0));
+
+            THEN("It uses it to strengthen the bound on b") {
+                CHECK(pre.model().lower_bound(a) == 0.0);  // unchanged
+                CHECK(pre.model().lower_bound(b) == 50.0);
+
+                AND_WHEN("we then apply domain propagation to the b - 2a <= -100 constraint") {
+                    pre.technique_domain_propagation(pre.model().constraint_ref(c1));
+
+                    THEN("It strengthens the bound on a") {
+                        CHECK(pre.model().lower_bound(a) == 75.0);
+                        CHECK(pre.model().lower_bound(b) == 50.0);  // unchanged
+                    }
+                }
+            }
+        }
+    }
+
+    GIVEN("A CQM with two cont. variables and two >= constraints that can strengthen eachother") {
+        auto cqm = ConstrainedQuadraticModel();
+        auto a = cqm.add_variable(dimod::Vartype::REAL);
+        auto b = cqm.add_variable(dimod::Vartype::REAL);
+
+        // NB: this is actually infeasible
+        auto c0 = cqm.add_linear_constraint({a, b}, {1, -2}, dimod::Sense::GE, 100);
+        auto c1 = cqm.add_linear_constraint({a, b}, {-2, 1}, dimod::Sense::GE, 100);
+
+        auto pre = PresolverImpl(cqm);
+
+        WHEN("we apply domain propagation to the a - 2b >= 100 constraint") {
+            pre.technique_domain_propagation(pre.model().constraint_ref(c0));
+
+            THEN("It uses it to strengthen the bound on a") {
+                CHECK(pre.model().lower_bound(a) == 100.0);
+                CHECK(pre.model().lower_bound(b) == 0.0);  // unchanged
+
+                AND_WHEN("we then apply domain propagation to the second constraint") {
+                    pre.technique_domain_propagation(pre.model().constraint_ref(c1));
+
+                    THEN("It strengthens the bound on a") {
+                        CHECK(pre.model().lower_bound(a) == 100.0);  // unchanged
+                        CHECK(pre.model().lower_bound(b) == 300.0);
+                    }
+                }
+            }
+        }
+    }
+}
+
+TEST_CASE("Test technique_remove_small_biases", "[presolve][impl]") {
+    GIVEN("A linear CQM with small biases") {
+        auto cqm = ConstrainedQuadraticModel();
+        cqm.add_variables(dimod::Vartype::BINARY, 2);
+        cqm.objective.set_linear(0, 1e-11);
+        cqm.objective.set_linear(1, -4);
+        cqm.add_linear_constraint({1, 0}, {1e-11, 4}, dimod::Sense::LE, 100);
+
+        WHEN("We apply technique_remove_small_biases()") {
+            CHECK(PresolverImpl::technique_remove_small_biases(cqm.objective));
+            CHECK(PresolverImpl::technique_remove_small_biases(cqm.constraint_ref(0)));
+
+            THEN("The variables with small linear biases are removed from the expressions") {
+                CHECK(cqm.objective.variables() == std::vector{1});
+                CHECK(cqm.constraint_ref(0).variables() == std::vector{0});
+            }
+        }
+
+        WHEN("We add quadratic biases to the expressions") {
+            cqm.objective.set_quadratic(0, 1, 1);
+            cqm.constraint_ref(0).set_quadratic(0, 1, -1);
+
+            AND_WHEN("We apply technique_remove_small_biases()") {
+                CHECK(PresolverImpl::technique_remove_small_biases(cqm.objective));
+                CHECK(PresolverImpl::technique_remove_small_biases(cqm.constraint_ref(0)));
+
+                THEN("The variables with small linear biases are not removed from the expressions "
+                     "but their linear biases are zeroed") {
+                    CHECK(cqm.objective.variables() == std::vector{0, 1});
+                    CHECK(cqm.constraint_ref(0).variables() == std::vector{1, 0});
+                    CHECK(cqm.objective.linear(0) == 0.0);
+                    CHECK(cqm.constraint_ref(0).linear(1) == 0.0);
+                }
+            }
+        }
+
+        WHEN("We add small quadratic biases to the expressions") {
+            cqm.objective.set_quadratic(0, 1, 1e-11);
+            cqm.constraint_ref(0).set_quadratic(0, 1, -1e-11);
+
+            AND_WHEN("We apply technique_remove_small_biases()") {
+                CHECK(PresolverImpl::technique_remove_small_biases(cqm.objective));
+                CHECK(PresolverImpl::technique_remove_small_biases(cqm.constraint_ref(0)));
+
+                THEN("The variables with small biases are removed from the expressions") {
+                    CHECK(cqm.objective.variables() == std::vector{1});
+                    CHECK(cqm.constraint_ref(0).variables() == std::vector{0});
+                }
+            }
+        }
+
+        WHEN("We run PresolverImpl::apply() without any techniques loaded") {
+            auto pre = PresolverImpl(cqm);
+            CHECK(!pre.apply());
+        }
+
+        WHEN("We run PresolverImpl::apply() with RemoveSmallBiases loaded") {
+            auto pre = PresolverImpl(cqm);
+            pre.techniques = presolve::TechniqueFlags::RemoveSmallBiases;
+            CHECK(pre.apply());
+
+            THEN("The variables with small linear biases are removed from the expressions") {
+                CHECK(pre.model().objective.variables() == std::vector{1});
+                CHECK(pre.model().constraint_ref(0).variables() == std::vector{0});
+            }
+        }
+    }
+
+    GIVEN("A linear CQM with biases that could be conditionally removed") {
+        auto cqm = ConstrainedQuadraticModel();
+        cqm.add_variables(dimod::Vartype::REAL, 3);
+
+        cqm.set_lower_bound(0, -1e-5);
+        cqm.set_upper_bound(0, 0);
+        cqm.set_lower_bound(1, -1e-5);
+        cqm.set_upper_bound(1, 0);
+
+        // x0 should trigger the conditional removal, x1 should not, x2 should trigger the
+        // first test, but not the second so shouldn't be removed
+        cqm.add_linear_constraint({1, 0, 2}, {1, .0003, .0003}, dimod::Sense::LE, 100);
+
+        // none should be removed from the objective
+        cqm.objective.set_linear(0, .0003);
+        cqm.objective.set_linear(2, .0003);
+        cqm.objective.set_linear(1, 1);
+
+        WHEN("We apply technique_remove_small_biases()") {
+            CHECK(!PresolverImpl::technique_remove_small_biases(cqm.objective));
+            CHECK(PresolverImpl::technique_remove_small_biases(cqm.constraint_ref(0)));
+
+            THEN("The variables with small linear biases are removed from the constraint") {
+                CHECK(cqm.constraint_ref(0).variables() == std::vector{1, 2});
+                CHECK(cqm.constraint_ref(0).linear(1) == 1.0);
+                CHECK(cqm.constraint_ref(0).linear(2) == .0003);
+                CHECK(!cqm.constraint_ref(0).offset());
+                CHECK(cqm.constraint_ref(0).rhs() == Approx(100 - 1e-5 * .0003));
+            }
+
+            THEN("The objective is not changed") {
+                CHECK(cqm.objective.variables() == std::vector{0, 2, 1});
+            }
+        }
+
+        WHEN("We add quadratic bias") {
+            cqm.constraint_ref(0).add_quadratic(0, 1, 1);
+
+            AND_WHEN("We apply technique_remove_small_biases()") {
+                PresolverImpl::technique_remove_small_biases(cqm.objective);
+
+                THEN("There is no conditional removal") {
+                    CHECK(cqm.constraint_ref(0).variables() == std::vector{1, 0, 2});
+                }
             }
         }
     }


### PR DESCRIPTION
Turns out that all of our presolve techniques can be replaced by just three: remove small biases, domain propagation, remove redundant constraints.

I implemented/re-implemented those methods, fixed a pile of bugs, and added more technique-specific testing.

I kept the changes to the Python interface as minimal as possible. I will do a refactor pass on propagating infeasibility into Python later.