### PR TITLE
Refactor error handling and infeasibility in presolve

### DIFF
--- a/dwave/preprocessing/include/dwave/flags.hpp
+++ b/dwave/preprocessing/include/dwave/flags.hpp
@@ -19,9 +19,9 @@
 namespace dwave::presolve {
 
 enum Feasibility {
-    Unknown,     //< It is not known if the model is feasible or not
     Infeasible,  //< The model is known to be infeasible
     Feasible,    //< The model is known to be feasible
+    Unknown,     //< It is not known if the model is feasible or not
 };
 
 enum TechniqueFlags : std::uint64_t {

--- a/dwave/preprocessing/include/dwave/presolve.hpp
+++ b/dwave/preprocessing/include/dwave/presolve.hpp
@@ -46,7 +46,7 @@ class Presolver {
     explicit Presolver(model_type model);
 
     /// Apply any loaded presolve techniques. Acts on the model() in-place.
-    void apply();
+    bool apply();
 
     /// Detach the constrained quadratic model and return it.
     /// This clears the model from the presolver.
@@ -59,6 +59,12 @@ class Presolver {
 
     /// Return a const reference to the held constrained quadratic model.
     const model_type& model() const;
+
+    /// Normalize the model.
+    bool normalize();
+
+    /// Presolve a normalized model.
+    bool presolve();
 
     /// Return a sample of the original CQM from a sample of the reduced CQM.
     std::vector<assignment_type> restore(std::vector<assignment_type> reduced) const;

--- a/dwave/preprocessing/libcpp.pxd
+++ b/dwave/preprocessing/libcpp.pxd
@@ -33,9 +33,11 @@ cdef extern from "dwave/presolve.hpp" namespace "dwave::presolve" nogil:
 
         Presolver()
         Presolver(model_type)
-        void apply() except+
+        bint apply() except+
         model_type detach_model()
         const Feasibility& feasibility() const
         void load_default_presolvers()
         model_type& model()
+        bint normalize() except+
+        bint presolve() except+
         vector[assignment_type] restore(vector[assignment_type])

--- a/dwave/preprocessing/presolve/cypresolve.pyi
+++ b/dwave/preprocessing/presolve/cypresolve.pyi
@@ -12,8 +12,16 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+import enum
+
 import dimod
 import numpy as np
+
+
+class Feasibility(enum.Enum):
+    Infeasible = 0
+    Feasible = 1
+    Unknown = 2
 
 
 class cyPresolver:
@@ -24,5 +32,6 @@ class cyPresolver:
     def clear_model(self) -> None: ...
     def copy_model(self) -> dimod.ConstrainedQuadraticModel: ...
     def detach_model(self) -> dimod.ConstrainedQuadraticModel: ...
+    def feasibility(self) -> Feasibility: ...
     def load_default_presolvers(self) -> None: ...
     def restore_samples(self, samples_like: dimod.typing.SamplesLike) -> np.ndarray: ...

--- a/dwave/preprocessing/presolve/exceptions.py
+++ b/dwave/preprocessing/presolve/exceptions.py
@@ -13,10 +13,6 @@
 #    limitations under the License.
 
 
-class InfeasibleModelError(ValueError):
-    pass
-
-
 class InvalidModelError(ValueError):
     """Error for models that are ill-constructed or otherwise not valid.
 

--- a/dwave/preprocessing/presolve/exceptions.py
+++ b/dwave/preprocessing/presolve/exceptions.py
@@ -1,4 +1,4 @@
-# Copyright 2022 D-Wave Systems Inc.
+# Copyright 2023 D-Wave Systems Inc.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -12,5 +12,14 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-from dwave.preprocessing.presolve.pypresolve import *
-from dwave.preprocessing.presolve.exceptions import *
+
+class InfeasibleModelError(ValueError):
+    pass
+
+
+class InvalidModelError(ValueError):
+    """Error for models that are ill-constructed or otherwise not valid.
+
+    This is disctinct from infeasibility.
+    """
+    pass

--- a/dwave/preprocessing/presolve/pypresolve.py
+++ b/dwave/preprocessing/presolve/pypresolve.py
@@ -88,9 +88,9 @@ You can also create the sample set for the original CQM:
 
 import dimod
 
-from dwave.preprocessing.presolve.cypresolve import cyPresolver
+from dwave.preprocessing.presolve.cypresolve import cyPresolver, Feasibility
 
-__all__ = ['Presolver']
+__all__ = ["Feasibility", "Presolver"]
 
 
 class Presolver(cyPresolver):

--- a/dwave/preprocessing/presolve/pypresolve.py
+++ b/dwave/preprocessing/presolve/pypresolve.py
@@ -90,11 +90,7 @@ import dimod
 
 from dwave.preprocessing.presolve.cypresolve import cyPresolver
 
-__all__ = ['Presolver', 'InfeasibleModelError']
-
-
-class InfeasibleModelError(ValueError):
-    pass
+__all__ = ['Presolver']
 
 
 class Presolver(cyPresolver):
@@ -144,13 +140,3 @@ class Presolver(cyPresolver):
     # include this for the function signature
     def __init__(self, cqm: dimod.ConstrainedQuadraticModel, *, move: bool = False):
         super().__init__(cqm, move=move)
-
-    def apply(self):
-        try:
-            super().apply()
-        except RuntimeError as err:
-            if str(err) == 'infeasible':
-                # checking based on the string is not ideal, but Cython is
-                # not-so-good at custom exceptions
-                raise InfeasibleModelError("given CQM is infeasible") from err
-            raise err

--- a/dwave/preprocessing/src/presolve.cpp
+++ b/dwave/preprocessing/src/presolve.cpp
@@ -36,8 +36,8 @@ Presolver<Bias, Index, Assignment>::Presolver(dimod::ConstrainedQuadraticModel<B
         : impl_(std::make_unique<PresolverImpl_>(std::move(model))) {}
 
 template <class Bias, class Index, class Assignment>
-void Presolver<Bias, Index, Assignment>::apply() {
-    impl_->apply();
+bool Presolver<Bias, Index, Assignment>::apply() {
+    return impl_->apply();
 }
 
 template <class Bias, class Index, class Assignment>
@@ -59,6 +59,16 @@ template <class Bias, class Index, class Assignment>
 const dimod::ConstrainedQuadraticModel<Bias, Index>& Presolver<Bias, Index, Assignment>::model()
         const {
     return impl_->model();
+}
+
+template <class Bias, class Index, class Assignment>
+bool Presolver<Bias, Index, Assignment>::normalize() {
+    return impl_->normalize();
+}
+
+template <class Bias, class Index, class Assignment>
+bool Presolver<Bias, Index, Assignment>::presolve() {
+    return impl_->presolve();
 }
 
 template <class Bias, class Index, class Assignment>

--- a/releasenotes/notes/presolve-refactor-d9c3d2fc91715c8e.yaml
+++ b/releasenotes/notes/presolve-refactor-d9c3d2fc91715c8e.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - Add ``dwave::presolve::Presolve::normalize()`` C++ method.
+  - Add ``dwave::presolve::Presolve::presolve()`` C++ method.
+  - Raise an ``InvalidModelError`` from ``Presolver`` when given a model with ``float("nan")`` biases.
+upgrade:
+  - Raise an ``InvalidModelError`` rather than a ``RuntimeError`` when presolving a detached model.

--- a/releasenotes/notes/presolve-refactor-d9c3d2fc91715c8e.yaml
+++ b/releasenotes/notes/presolve-refactor-d9c3d2fc91715c8e.yaml
@@ -3,5 +3,10 @@ features:
   - Add ``dwave::presolve::Presolve::normalize()`` C++ method.
   - Add ``dwave::presolve::Presolve::presolve()`` C++ method.
   - Raise an ``InvalidModelError`` from ``Presolver`` when given a model with ``float("nan")`` biases.
+  - |
+    Add ``Presolver.feasibility()`` method to return a ``Feasibility`` enum. This can be used to test
+    the feasibility of presolved models.
 upgrade:
   - Raise an ``InvalidModelError`` rather than a ``RuntimeError`` when presolving a detached model.
+  - Change ``Presolver`` to no longer raise an ``InfeasibleModelError`` error for infeasible models.
+  - Remove the ``InfeasibleModelError``.

--- a/tests/test_presolve.py
+++ b/tests/test_presolve.py
@@ -18,7 +18,8 @@ import unittest
 import dimod
 import numpy as np
 
-from dwave.preprocessing import Presolver, InfeasibleModelError
+from dwave.preprocessing import Presolver
+from dwave.preprocessing import InvalidModelError, InfeasibleModelError
 
 
 class TestPresolver(unittest.TestCase):
@@ -142,7 +143,17 @@ class TestPresolver(unittest.TestCase):
         model = presolver.detach_model()
         self.assertEqual(len(model.variables), 1)
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(InvalidModelError):
+            presolver.apply()
+
+    def test_invalid_model(self):
+        cqm = dimod.CQM()
+        i = cqm.add_variable("INTEGER")
+        cqm.objective.set_linear(i, float("nan"))
+
+        presolver = Presolver(cqm)
+
+        with self.assertRaises(InvalidModelError):
             presolver.apply()
 
     def test_move(self):

--- a/tests/test_presolve.py
+++ b/tests/test_presolve.py
@@ -18,8 +18,7 @@ import unittest
 import dimod
 import numpy as np
 
-from dwave.preprocessing import Presolver
-from dwave.preprocessing import InvalidModelError, InfeasibleModelError
+from dwave.preprocessing import Presolver, Feasibility, InvalidModelError
 
 
 class TestPresolver(unittest.TestCase):
@@ -201,8 +200,8 @@ class TestPresolver(unittest.TestCase):
 
             presolver = Presolver(cqm)
             presolver.load_default_presolvers()
-            with self.assertRaises(InfeasibleModelError):
-                presolver.apply()
+            presolver.apply()
+            self.assertIs(presolver.feasibility(), Feasibility.Infeasible)
 
         with self.subTest("infeas =="):
             cqm = dimod.ConstrainedQuadraticModel()
@@ -212,8 +211,8 @@ class TestPresolver(unittest.TestCase):
 
             presolver = Presolver(cqm)
             presolver.load_default_presolvers()
-            with self.assertRaises(InfeasibleModelError):
-                presolver.apply()
+            presolver.apply()
+            self.assertIs(presolver.feasibility(), Feasibility.Infeasible)
 
         with self.subTest("infeas >="):
             cqm = dimod.ConstrainedQuadraticModel()
@@ -223,8 +222,8 @@ class TestPresolver(unittest.TestCase):
 
             presolver = Presolver(cqm)
             presolver.load_default_presolvers()
-            with self.assertRaises(InfeasibleModelError):
-                presolver.apply()
+            presolver.apply()
+            self.assertIs(presolver.feasibility(), Feasibility.Infeasible)
 
     def test_self_loop(self):
         i = dimod.Integer("i")


### PR DESCRIPTION
Change the behavior of the presolver for infeasible models. Infeasible models will no longer raise an error but instead they will set a flag that can be used by the user to do determine what to do. This avoids needing to use exceptions to determine program flow.

**This is a backwards compatibility break.**

Closes https://github.com/dwavesystems/dwave-preprocessing/issues/61 by virtue of no longer raising an error when the model is infeasible and improving the error message for invalid models.