### PR TITLE
Release the GIL during presolve

### DIFF
--- a/dwave/preprocessing/presolve/cypresolve.pxd
+++ b/dwave/preprocessing/presolve/cypresolve.pxd
@@ -23,8 +23,19 @@ from dwave.preprocessing.libcpp cimport Presolver as cppPresolver
 __all__ = ['cyPresolver']
 
 
+cdef extern from "<mutex>" namespace "std" nogil:
+    cppclass mutex:
+        void lock()
+        void unlock()
+
+    cppclass lock_guard "std::lock_guard<std::mutex>":
+        lock_guard(mutex&)
+
+
 cdef class cyPresolver:
     cdef cppPresolver[bias_type, index_type, double]* cpppresolver  # dev note: terrible name...
+
+    cdef mutex mutex
     
     cdef cyVariables _original_variables
     cdef Py_ssize_t _model_num_variables

--- a/dwave/preprocessing/presolve/cypresolve.pxd
+++ b/dwave/preprocessing/presolve/cypresolve.pxd
@@ -28,9 +28,6 @@ cdef extern from "<mutex>" namespace "std" nogil:
         void lock()
         void unlock()
 
-    cppclass lock_guard "std::lock_guard<std::mutex>":
-        lock_guard(mutex&)
-
 
 cdef class cyPresolver:
     cdef cppPresolver[bias_type, index_type, double]* cpppresolver  # dev note: terrible name...

--- a/dwave/preprocessing/presolve/cypresolve.pyx
+++ b/dwave/preprocessing/presolve/cypresolve.pyx
@@ -18,8 +18,6 @@ import enum as pyenum
 
 cimport cython
 
-from libc.stdlib cimport free
-from libcpp.memory cimport unique_ptr, make_unique
 from libcpp.vector cimport vector
 from libcpp.utility cimport move as cppmove
 

--- a/dwave/preprocessing/presolve/cypresolve.pyx
+++ b/dwave/preprocessing/presolve/cypresolve.pyx
@@ -137,7 +137,8 @@ cdef class cyPresolver:
         cdef bint changes = False
 
         try:
-            changes = self.cpppresolver.normalize()
+            with nogil:
+                changes = self.cpppresolver.normalize()
         except RuntimeError as err:
             # The C++ InvalidModelError is interpreted by Cython as a RuntimeError
             # We could put in a bunch of code to reinterpret it, but because this
@@ -164,7 +165,8 @@ cdef class cyPresolver:
         cdef bint changes = False
 
         try:
-            changes = self.cpppresolver.presolve()
+            with nogil:
+                changes = self.cpppresolver.presolve()
         except RuntimeError as err:
             # The C++ logic_error is interpreted by Cython as a RuntimeError.
             # The only errors here should be for a model that's not normalized.

--- a/releasenotes/notes/presolve-nogil-9f000e3179f36084.yaml
+++ b/releasenotes/notes/presolve-nogil-9f000e3179f36084.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Update ``Presolver.apply()``, ``Presolver.normalize()``, and ``Presolver.presolve()``
+    to release Python's global interpreter lock (GIL).

--- a/tests/test_presolve.py
+++ b/tests/test_presolve.py
@@ -12,6 +12,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+import concurrent.futures
 import os.path
 import unittest
 
@@ -39,6 +40,36 @@ class TestApply(unittest.TestCase):
 class TestNormalization(unittest.TestCase):
     # Developer note: most of the testing for normalization is done at the C++
     # level. These tests are mostly testing the Cython/Python interface.
+
+    def test_concurrency(self):
+        # obviously this is difficult to test fully, but we can at least run some
+        # smoke tests to try to detect deadlocks and corrupted models
+
+        cqm = dimod.ConstrainedQuadraticModel()
+        cqm.add_variables("BINARY", 1000)
+        for _ in range(1000):
+            # these will be flipped, so if we're modifying the same model in
+            # several threads at the same time we should see some issues
+            cqm.add_constraint(((v, 1) for v in range(1000)), '>=', 1)
+
+        presolver = Presolver(cqm)
+
+        num_threads = 4
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=num_threads) as executor:
+            concurrent.futures.wait(
+                [executor.submit(presolver.normalize) for i in range(num_threads)])
+
+        cqm = presolver.detach_model()
+
+        self.assertEqual(cqm.num_variables(), 1000)
+        self.assertEqual(cqm.num_constraints(), 1000)
+
+        linear = {v: -1 for v in range(1000)}
+        for comp in cqm.constraints.values():
+            self.assertEqual(comp.rhs, -1)
+            self.assertEqual(comp.sense, dimod.sym.Sense.Le)
+            self.assertEqual(comp.lhs.linear, linear)
 
     def test_empty(self):
         presolver = Presolver(dimod.ConstrainedQuadraticModel())
@@ -69,6 +100,34 @@ class TestNormalization(unittest.TestCase):
 class TestPresolve(unittest.TestCase):
     # Developer note: most of the testing for presolve is done at the C++
     # level. These tests are mostly testing the Cython/Python interface.
+
+    def test_concurrency(self):
+        # obviously this is difficult to test fully, but we can at least run some
+        # smoke tests to try to detect deadlocks and corrupted models
+
+        cqm = dimod.ConstrainedQuadraticModel()
+        cqm.add_variables("INTEGER", 100)
+        for i in range(100):
+            # these will be presolved, so if we're modifying the same model in
+            # several threads at the same time we should see some issues
+            cqm.add_constraint(((v, 1) for v in range(i, 100)), '==', 1)
+
+        presolver = Presolver(cqm)
+        presolver.load_default_presolvers()
+        presolver.normalize()
+
+        num_threads = 4
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=num_threads) as executor:
+            jobs = [executor.submit(presolver.presolve) for i in range(num_threads)]
+
+        # presolve should only make any changes once
+        self.assertEqual(sum(future.result() for future in jobs), 1)
+
+        cqm = presolver.detach_model()
+
+        self.assertEqual(cqm.num_variables(), 0)
+        self.assertEqual(cqm.num_constraints(), 0)
 
     def test_empty(self):
         presolver = Presolver(dimod.ConstrainedQuadraticModel())

--- a/tests/test_presolve.py
+++ b/tests/test_presolve.py
@@ -21,6 +21,12 @@ import numpy as np
 
 from dwave.preprocessing import Presolver, Feasibility, InvalidModelError
 
+try:
+    NUM_CPUS = len(os.sched_getaffinity(0))
+except AttributeError:
+    # windows
+    NUM_CPUS = os.cpu_count()
+
 
 class TestApply(unittest.TestCase):
     # Developer note: most of the testing for normalization/presolve is done at the C++
@@ -41,6 +47,7 @@ class TestNormalization(unittest.TestCase):
     # Developer note: most of the testing for normalization is done at the C++
     # level. These tests are mostly testing the Cython/Python interface.
 
+    @unittest.skipIf(NUM_CPUS < 4, "insufficient CPUs available")
     def test_concurrency(self):
         # obviously this is difficult to test fully, but we can at least run some
         # smoke tests to try to detect deadlocks and corrupted models
@@ -101,6 +108,7 @@ class TestPresolve(unittest.TestCase):
     # Developer note: most of the testing for presolve is done at the C++
     # level. These tests are mostly testing the Cython/Python interface.
 
+    @unittest.skipIf(NUM_CPUS < 4, "insufficient CPUs available")
     def test_concurrency(self):
         # obviously this is difficult to test fully, but we can at least run some
         # smoke tests to try to detect deadlocks and corrupted models


### PR DESCRIPTION
I tried adding a test [similar to the ones in dwave-samplers](https://github.com/dwavesystems/dwave-samplers/blob/bc79129509d8fedfc9bfb4a64ec2babe83f71f63/tests/test_simulated_annealing.py#L237-L265) to test concurrency, but because presolve is so fast relative to model construction it slowed the tests down mightily.

I was able to detect the change locally by running with some large problems from [MIPLIB](https://miplib.zib.de/).