### PR TITLE
Fix the handling of quadratic constraints in presolve

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "wheel>=0.30.0",
     "Cython>=0.29.21,<3.0",
     'oldest-supported-numpy',
-    "dimod==0.12.9",
+    "dimod==0.12.10",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/releasenotes/notes/fix-presolve-quadratic-9b554f5cefccb40c.yaml
+++ b/releasenotes/notes/fix-presolve-quadratic-9b554f5cefccb40c.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fix the handling of quadratic constraints in presolve. Previously fixing
+    variables in quadratic constraints would result in memory errors.
+    See `dimod#1351 <https://github.com/dwavesystems/dimod/issues/1351>`_.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dimod==0.12.9
+dimod==0.12.10
 Cython==0.29.28
 oldest-supported-numpy
 


### PR DESCRIPTION
No code changes, but because dimod is currently header-only we need to rebuilt the library in order to get the fixes. I did add some tests confirming the fix.

The error was fixed in dimod 0.12.10. See https://github.com/dwavesystems/dimod/issues/1351