### PR TITLE
Fix c++ build warnings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,10 +83,8 @@ import dwave.preprocessing
 import os
 config_directory = os.path.dirname(os.path.abspath(__file__))
 
-breathe_default_project = "preprocessing"
-breathe_projects = dict(
-  preprocessing=os.path.join(config_directory, 'build-cpp', 'xml'),
-  )
+breathe_default_project = "dwave-preprocessing"
+breathe_projects = {'dwave-preprocessing': os.path.join(config_directory, 'build-cpp', 'xml')}
 
 # see https://breathe.readthedocs.io/en/latest/readthedocs.html
 if os.environ.get('READTHEDOCS', False):

--- a/docs/reference/presolve.rst
+++ b/docs/reference/presolve.rst
@@ -46,14 +46,14 @@ TechniqueFlags
 C++ API
 -------
 
-.. doxygenclass:: dwave::presolve::Feasibility
-    :members:
-    :project: dwave-preprocessing
-
-.. doxygenclass:: dwave::presolve::TechniqueFlags
-    :members:
-    :project: dwave-preprocessing
-
 .. doxygenclass:: dwave::presolve::Presolver
     :members:
     :project: dwave-preprocessing
+
+.. doxygenenum:: dwave::presolve::Feasibility
+    :project: dwave-preprocessing
+
+.. doxygenenum:: dwave::presolve::TechniqueFlags
+    :project: dwave-preprocessing
+
+

--- a/dwave/preprocessing/include/dwave-preprocessing/fix_variables.hpp
+++ b/dwave/preprocessing/include/dwave-preprocessing/fix_variables.hpp
@@ -42,6 +42,7 @@ public:
  *      that do not contribute any coefficient to the posiform are set to 1. This
  *      may happen if their bias in the original QUBO was 0 or if they were flushed
  *      to zero when converted to the posiform.
+ * @param fixed_variables Variable to fix.
  */
 template <class PosiformInfo>
 capacity_type fixQuboVariables(PosiformInfo &posiform_info, int num_bqm_variables,

--- a/dwave/preprocessing/include/dwave-preprocessing/fix_variables.hpp
+++ b/dwave/preprocessing/include/dwave-preprocessing/fix_variables.hpp
@@ -42,7 +42,7 @@ public:
  *      that do not contribute any coefficient to the posiform are set to 1. This
  *      may happen if their bias in the original QUBO was 0 or if they were flushed
  *      to zero when converted to the posiform.
- * @param fixed_variables Variable to fix.
+ * @param fixed_variables Variables to fix.
  */
 template <class PosiformInfo>
 capacity_type fixQuboVariables(PosiformInfo &posiform_info, int num_bqm_variables,


### PR DESCRIPTION
Part of [sdk](https://github.com/dwavesystems/dwave-ocean-sdk/pull/300) cleanup of build warnings. 
Currently SDK builds have the following warnings,
```
Cannot find class "dwave::presolve::Feasibility" in doxygen xml
Cannot find class "dwave::presolve::TechniqueFlags" in doxygen xml
fix_variables.hpp:47: warning: The following parameter of fix_variables_::fixQuboVariables(PosiformInfo &posiform_info, int num_bqm_variables, bool strict, std::vector< std::pair< int, int >> &fixed_variables) is not documented:
  parameter 'fixed_variables'
```
and local has,
```
WARNING: doxygenfunction: Unable to find project 'dwave-preprocessing' in breathe_projects dictionary
```
This fixes the first two by using ``doxygenenum`` instead of ``doxygenclass`` --- if there's a better way, I'd like to hear of it.
It also enables local builds of the C++ docs.