### PR TITLE
Release 0.6.9

### DIFF
--- a/dwave/preprocessing/__init__.py
+++ b/dwave/preprocessing/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.6.8'
+__version__ = '0.6.9'
 
 from dwave.preprocessing import *
 import dwave.preprocessing.composites


### PR DESCRIPTION
### New Features

-   Propagate `SampleSet.info` from child sampler in `SpinReversalTransformComposite` in the unambiguous case of a single spin reversal transform. See [dimod\#111](https://github.com/dwavesystems/dimod/issues/111), [dwave-system\#564](https://github.com/dwavesystems/dwave-system/issues/564) and [\#147](https://github.com/dwavesystems/dwave-preprocessing/pull/147).

### Upgrade Notes

-   Switch from pkgutil-style namespace package to native namespace package (PEP 420). While native namespace packages and pkgutil-style namespace packages are largely compatible, we recommend using only native ones going forward. See [\#155](https://github.com/dwavesystems/dwave-preprocessing/pull/155).
