### PR TITLE
Fix docbuild warnings & update stale settings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ extensions = [
 autosummary_generate = True
 
 # The suffix(es) of source filenames.
-source_suffix = ['.rst', '.md']
+source_suffix = {'.rst': 'restructuredtext', '.md': 'restructuredtext'}
 
 # The master toctree document.
 master_doc = 'index'

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-pydata-sphinx-theme==0.14.3
-sphinx==7.3.7
-breathe==4.35.0
+pydata-sphinx-theme==0.16.1
+sphinx==8.2.3
+breathe>4.35

--- a/dwave/preprocessing/composites/spin_reversal_transform.py
+++ b/dwave/preprocessing/composites/spin_reversal_transform.py
@@ -25,25 +25,23 @@ __all__ = ['SpinReversalTransformComposite']
 # versionadded (0.6.8) to the __init__ file for context manager
 
 class SpinReversalTransformComposite(ComposedSampler):
-    """Composite for applying spin reversal transform preprocessing.
+    r"""Composite for applying spin reversal transform preprocessing.
 
-    A spin-reversal transform can improve sample statistics when the 
-    sampler is a physical object with asymmetries such as a QPU.
-    The technique works as follows: given an :math:`n`-variable Ising 
-    problem, the composite selects a random :math:`g\in\{\pm1\}^n` and 
-    transforms the problem via :math:`h_i\mapsto h_ig_i` and 
-    :math:`J_{ij}\mapsto J_{ij}g_ig_j`. Solutions :math:`s` of the 
-    original problem and :math:`s^\prime` of the transformed problem 
-    are related by :math:`s^\prime_i=s_ig_i` and have identical energies. 
-    [#km]_
+    A spin-reversal transform can improve sample statistics when the sampler is
+    a physical object with asymmetries such as a QPU.
+    The technique works as follows: given an :math:`n`-variable Ising problem,
+    the composite selects a random :math:`g\in\{\pm1\}^n` and transforms the
+    problem via :math:`h_i\mapsto h_ig_i` and
+    :math:`J_{ij}\mapsto J_{ij}g_ig_j`. Solutions :math:`s` of the original
+    problem and :math:`s^\prime` of the transformed problem are related by
+    :math:`s^\prime_i=s_ig_i` and have identical energies.\ [#km]_
 
     .. note::
         If you are configuring an anneal schedule, be mindful that this
-        composite does not recognize the ``initial_state`` parameter 
-        used by dimod's :class:`~dwave.system.samplers.DWaveSampler` for 
-        reverse annealing (composites do not generally process all keywords 
-        of child samplers) and does not flip any of the configured initial 
-        states. 
+        composite does not recognize the ``initial_state`` parameter used by
+        dimod's :class:`~dwave.system.samplers.DWaveSampler` for reverse
+        annealing (composites do not generally process all keywords of child
+        samplers) and does not flip any of the configured initial states.
 
     Args:
         sampler: A `dimod` sampler object.


### PR DESCRIPTION
SDK [build warnings](https://app.circleci.com/pipelines/github/dwavesystems/dwave-ocean-sdk/3387/workflows/4a43a62c-07d8-4543-9a5c-399daf6722b9/jobs/48328):

```
<unknown>:33: SyntaxWarning: invalid escape sequence '\i'_ref
<unknown>:33: SyntaxWarning: invalid escape sequence '\i'
<unknown>:33: SyntaxWarning: invalid escape sequence '\i'erated/dwave.preprocessing.composites.__init__.SpinReversalTransformComposite.child
<unknown>:33: SyntaxWarning: invalid escape sequence '\i'erated/dwave.preprocessing.composites.__init__.SpinReversalTransformComposite.children
<unknown>:33: SyntaxWarning: invalid escape sequence '\i'erated/dwave.preprocessing.composites.__init__.SpinReversalTransformComposite.parameters
<unknown>:33: SyntaxWarning: invalid escape sequence '\i'erated/dwave.preprocessing.composites.__init__.SpinReversalTransformComposite.properties
```

Also matched requirements on sphinx to current SDK. For ``breathe 4.35.0`` I get:

```
dwave_preprocessing_3_12_4\Lib\site-packages\breathe\directives\function.py", line 169, in _parse_args
        paramQual = parser._parse_parameters_and_qualifiers(paramMode="function")
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    TypeError: DefinitionParser._parse_parameters_and_qualifiers() got an unexpected keyword argument 'paramMode'
```

that is fixed in ``breathe-4.36.0``

